### PR TITLE
feat: refresh tokens and reorder channels

### DIFF
--- a/src/lib/client/api.ts
+++ b/src/lib/client/api.ts
@@ -1,5 +1,13 @@
 import { Configuration } from '$lib/api';
-import { AuthApi, GuildApi, MessageApi, SearchApi, UserApi, WebhookApi, SearchApiFactory } from '$lib/api';
+import {
+	AuthApi,
+	GuildApi,
+	MessageApi,
+	SearchApi,
+	UserApi,
+	WebhookApi,
+	SearchApiFactory
+} from '$lib/api';
 import axios, { type AxiosInstance } from 'axios';
 import { env as publicEnv } from '$env/dynamic/public';
 import { browser } from '$app/environment';
@@ -8,118 +16,181 @@ import { browser } from '$app/environment';
 // Injects the bearer token dynamically via configuration.accessToken.
 
 export type ApiGroup = {
-  auth: AuthApi;
-  guild: GuildApi;
-  message: MessageApi;
-  search: ReturnType<typeof SearchApiFactory>;
-  user: UserApi;
-  webhook: WebhookApi;
+	auth: AuthApi;
+	guild: GuildApi;
+	message: MessageApi;
+	search: ReturnType<typeof SearchApiFactory>;
+	user: UserApi;
+	webhook: WebhookApi;
 };
 
 function computeApiBase(): string {
-  const configured = (publicEnv?.PUBLIC_API_BASE_URL as string | undefined) || undefined;
-  if (configured && configured.trim().length > 0) {
-    return configured.replace(/\/+$/, '');
-  }
-  // Fallback: explicit localhost for both browser and SSR to avoid relying on a dev proxy
-  return 'http://localhost/api/v1';
+	const configured = (publicEnv?.PUBLIC_API_BASE_URL as string | undefined) || undefined;
+	if (configured && configured.trim().length > 0) {
+		return configured.replace(/\/+$/, '');
+	}
+	// Fallback: explicit localhost for both browser and SSR to avoid relying on a dev proxy
+	return 'http://localhost/api/v1';
 }
 
-export function createApi(getToken: () => string | null): ApiGroup {
-  const basePath = computeApiBase();
-  const config = new Configuration({
-    basePath
-  });
+export function createApi(
+	getToken: () => string | null,
+	refresh?: () => Promise<boolean>
+): ApiGroup {
+	const basePath = computeApiBase();
+	const config = new Configuration({
+		basePath
+	});
 
-  // Create a dedicated axios instance with an auth interceptor
-  const ax: AxiosInstance = axios.create();
+	// Create a dedicated axios instance with an auth interceptor
+	const ax: AxiosInstance = axios.create();
 
-  // Preserve large int64 values as strings to avoid precision loss
-  function parseJSONPreserveLargeInts(data: string) {
-    let out = '';
-    let i = 0;
-    let inStr = false;
-    let esc = false;
-    while (i < data.length) {
-      const ch = data[i];
-      if (inStr) {
-        out += ch;
-        if (esc) esc = false;
-        else if (ch === '\\') esc = true;
-        else if (ch === '"') inStr = false;
-        i++;
-        continue;
-      }
-      if (ch === '"') {
-        out += ch; inStr = true; i++; continue;
-      }
-      // potential number start
-      if (ch === '-' || (ch >= '0' && ch <= '9')) {
-        // look back for previous non-space
-        let p = i - 1;
-        while (p >= 0 && /\s/.test(data[p])) p--;
-        const prev = p >= 0 ? data[p] : '';
-        const okStart = p < 0 || prev === ':' || prev === '[' || prev === '{' || prev === ',';
-        if (okStart) {
-          const start = i;
-          let end = i;
-          let hasDot = false, hasExp = false;
-          if (data[end] === '-') end++;
-          while (end < data.length) {
-            const c = data[end];
-            if (c >= '0' && c <= '9') { end++; continue; }
-            if (!hasDot && c === '.') { hasDot = true; end++; continue; }
-            if (!hasExp && (c === 'e' || c === 'E')) {
-              hasExp = true; end++;
-              if (data[end] === '+' || data[end] === '-') end++;
-              while (end < data.length && data[end] >= '0' && data[end] <= '9') end++;
-              break;
-            }
-            break;
-          }
-          const numLiteral = data.slice(start, end);
-          if (!hasDot && !hasExp) {
-            const abs = numLiteral[0] === '-' ? numLiteral.slice(1) : numLiteral;
-            if (abs.length >= 16) {
-              out += '"' + numLiteral + '"';
-              i = end; continue;
-            }
-          }
-        }
-      }
-      out += ch; i++;
-    }
-    return JSON.parse(out);
-  }
+	// Preserve large int64 values as strings to avoid precision loss
+	function parseJSONPreserveLargeInts(data: string) {
+		let out = '';
+		let i = 0;
+		let inStr = false;
+		let esc = false;
+		while (i < data.length) {
+			const ch = data[i];
+			if (inStr) {
+				out += ch;
+				if (esc) esc = false;
+				else if (ch === '\\') esc = true;
+				else if (ch === '"') inStr = false;
+				i++;
+				continue;
+			}
+			if (ch === '"') {
+				out += ch;
+				inStr = true;
+				i++;
+				continue;
+			}
+			// potential number start
+			if (ch === '-' || (ch >= '0' && ch <= '9')) {
+				// look back for previous non-space
+				let p = i - 1;
+				while (p >= 0 && /\s/.test(data[p])) p--;
+				const prev = p >= 0 ? data[p] : '';
+				const okStart = p < 0 || prev === ':' || prev === '[' || prev === '{' || prev === ',';
+				if (okStart) {
+					const start = i;
+					let end = i;
+					let hasDot = false,
+						hasExp = false;
+					if (data[end] === '-') end++;
+					while (end < data.length) {
+						const c = data[end];
+						if (c >= '0' && c <= '9') {
+							end++;
+							continue;
+						}
+						if (!hasDot && c === '.') {
+							hasDot = true;
+							end++;
+							continue;
+						}
+						if (!hasExp && (c === 'e' || c === 'E')) {
+							hasExp = true;
+							end++;
+							if (data[end] === '+' || data[end] === '-') end++;
+							while (end < data.length && data[end] >= '0' && data[end] <= '9') end++;
+							break;
+						}
+						break;
+					}
+					const numLiteral = data.slice(start, end);
+					if (!hasDot && !hasExp) {
+						const abs = numLiteral[0] === '-' ? numLiteral.slice(1) : numLiteral;
+						if (abs.length >= 16) {
+							out += '"' + numLiteral + '"';
+							i = end;
+							continue;
+						}
+					}
+				}
+			}
+			out += ch;
+			i++;
+		}
+		return JSON.parse(out);
+	}
 
-  ax.defaults.transformResponse = [function (data) {
-    if (typeof data !== 'string') return data;
-    const trimmed = data.trim();
-    if (!trimmed) return data;
-    if (trimmed[0] === '{' || trimmed[0] === '[') {
-      try { return parseJSONPreserveLargeInts(trimmed); } catch { /* fallthrough */ }
-      try { return JSON.parse(trimmed); } catch { return data; }
-    }
-    return data;
-  }];
-  ax.interceptors.request.use((req) => {
-    const t = getToken();
-    if (t) {
-      req.headers = { ...(req.headers || {}), Authorization: `Bearer ${t}` } as any;
-    }
-    return req;
-  });
+	ax.defaults.transformResponse = [
+		function (data) {
+			if (typeof data !== 'string') return data;
+			const trimmed = data.trim();
+			if (!trimmed) return data;
+			if (trimmed[0] === '{' || trimmed[0] === '[') {
+				try {
+					return parseJSONPreserveLargeInts(trimmed);
+				} catch {
+					/* fallthrough */
+				}
+				try {
+					return JSON.parse(trimmed);
+				} catch {
+					return data;
+				}
+			}
+			return data;
+		}
+	];
+	function decodeExp(t: string): number | null {
+		try {
+			const part = t.split('.')[1] || '';
+			const json =
+				typeof atob === 'function' ? atob(part) : Buffer.from(part, 'base64').toString('utf8');
+			const payload = JSON.parse(json) as { exp?: number };
+			return typeof payload.exp === 'number' ? payload.exp : null;
+		} catch {
+			return null;
+		}
+	}
 
-  const base = config.basePath ?? basePath;
+	ax.interceptors.request.use(async (req) => {
+		let t = getToken();
+		if (t) {
+			const exp = decodeExp(t);
+			if (exp && Date.now() >= exp * 1000 && refresh) {
+				const ok = await refresh();
+				if (ok) t = getToken();
+			}
+			if (t) {
+				req.headers = { ...(req.headers || {}), Authorization: `Bearer ${t}` } as any;
+			}
+		}
+		return req;
+	});
 
-  const search = SearchApiFactory(config, base, ax);
+	ax.interceptors.response.use(
+		(res) => res,
+		async (error) => {
+			const status = error?.response?.status;
+			if (status === 401 && refresh && !error.config?._retry) {
+				error.config._retry = true;
+				const ok = await refresh();
+				if (ok) {
+					const t = getToken();
+					if (t) error.config.headers.Authorization = `Bearer ${t}`;
+					return ax(error.config);
+				}
+			}
+			throw error;
+		}
+	);
 
-  return {
-    auth: new AuthApi(config, base, ax),
-    guild: new GuildApi(config, base, ax),
-    message: new MessageApi(config, base, ax),
-    search,
-    user: new UserApi(config, base, ax),
-    webhook: new WebhookApi(config, base, ax)
-  };
+	const base = config.basePath ?? basePath;
+
+	const search = SearchApiFactory(config, base, ax);
+
+	return {
+		auth: new AuthApi(config, base, ax),
+		guild: new GuildApi(config, base, ax),
+		message: new MessageApi(config, base, ax),
+		search,
+		user: new UserApi(config, base, ax),
+		webhook: new WebhookApi(config, base, ax)
+	};
 }

--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -21,8 +21,10 @@
 	let channelError: string | null = $state(null);
 	let categoryError: string | null = $state(null);
 	let filter = $state('');
-	let collapsed = $state<Record<string, boolean>>({});
-	let creatingChannelParent: string | null = $state(null);
+        let collapsed = $state<Record<string, boolean>>({});
+        let creatingChannelParent: string | null = $state(null);
+        let dragging: { id: string; parent: string | null; type: number } | null = null;
+        let dragIndicator = $state<{ target: string | null; parent: string | null; mode: 'before' | 'inside' } | null>(null);
 
 	function currentGuildChannels(): DtoChannel[] {
 		const gid = $selectedGuildId ?? '';
@@ -60,31 +62,125 @@
 		}
 	}
 
-	function computeSections(channels: DtoChannel[]) {
-		const byParent: Record<string, DtoChannel[]> = {};
-		const idToChannel: Record<string, DtoChannel> = {};
-		const topLevel: DtoChannel[] = [];
-		for (const c of channels) {
-			if ((c as any).id != null) idToChannel[String((c as any).id)] = c;
+        function startDrag(ch: DtoChannel, parent: string | null) {
+                dragging = { id: String(ch.id as unknown as number), parent, type: (ch as any)?.type ?? 0 };
+        }
+
+        function dragOverChannel(id: string, parent: string | null) {
+                dragIndicator = { target: id, parent, mode: 'before' };
+        }
+
+        function dragOverContainer(parent: string | null) {
+                dragIndicator = { target: null, parent, mode: 'inside' };
+        }
+
+        function dropOnChannel(targetId: string, parent: string | null) {
+                if (!dragging) return;
+                moveChannel(dragging.id, dragging.parent, parent, targetId);
+                dragging = null;
+                dragIndicator = null;
+        }
+
+        function dropOnContainer(parent: string | null) {
+                if (!dragging) return;
+                moveChannel(dragging.id, dragging.parent, parent, null);
+                dragging = null;
+                dragIndicator = null;
+        }
+
+        function dropOnCategoryHeader(targetId: string) {
+                if (!dragging) return;
+                if (dragging.type === 2) {
+                        moveChannel(dragging.id, dragging.parent, null, targetId);
+                } else {
+                        moveChannel(dragging.id, dragging.parent, targetId, null);
+                }
+                dragging = null;
+                dragIndicator = null;
+        }
+
+	async function moveChannel(
+		id: string,
+		from: string | null,
+		to: string | null,
+		beforeId: string | null
+	) {
+		const gid = $selectedGuildId ? String($selectedGuildId) : '';
+		if (!gid) return;
+		const list = [...($channelsByGuild[gid] ?? [])];
+		const idx = list.findIndex((c) => String((c as any).id) === id);
+		if (idx === -1) return;
+		const [moving] = list.splice(idx, 1);
+		(moving as any).parent_id = to ? Number(to) : null;
+
+		let insertIndex = list.length;
+		if (beforeId) {
+			const targetIdx = list.findIndex((c) => String((c as any).id) === beforeId);
+			if (targetIdx !== -1) insertIndex = targetIdx;
 		}
-		const parentIds = new Set<string>();
-		for (const c of channels) {
-			if ((c as any).parent_id != null) {
-				const pid = String((c as any).parent_id);
-				parentIds.add(pid);
-				(byParent[pid] ||= []).push(c);
-			}
+		list.splice(insertIndex, 0, moving);
+		channelsByGuild.update((m) => ({ ...m, [gid]: list }));
+
+		if (from !== to) {
+			await auth.api.guild.guildGuildIdChannelChannelIdPatch({
+				guildId: Number(gid),
+				channelId: Number(id),
+				guildPatchGuildChannelRequest: { parent_id: to ? Number(to) : undefined }
+			});
 		}
-		for (const c of channels) {
-			const cid = String((c as any).id);
-			if ((c as any).parent_id == null && !parentIds.has(cid)) topLevel.push(c);
+
+		async function sendOrder(parent: string | null) {
+			const ids = list
+				.filter((c) => {
+					const pid = (c as any).parent_id == null ? null : String((c as any).parent_id);
+					return pid === (parent ? String(parent) : null);
+				})
+				.map((c) => Number((c as any).id));
+                        await auth.api.guild.guildGuildIdChannelOrderPatch(
+                                { guildId: Number(gid) },
+                                { params: { parent_id: parent ? Number(parent) : undefined, channel_id: ids } as any }
+                        );
 		}
-		const categories = [...parentIds].map((pid) => ({
-			cat: idToChannel[pid],
-			items: byParent[pid] ?? []
-		}));
-		return { categories, topLevel };
+
+		await sendOrder(from);
+		if (to !== from) await sendOrder(to);
 	}
+
+        function computeSections(channels: DtoChannel[]) {
+                const byParent: Record<string, DtoChannel[]> = {};
+                const idToChannel: Record<string, DtoChannel> = {};
+                const parentIds: string[] = [];
+                for (const c of channels) {
+                        if ((c as any).id != null) idToChannel[String((c as any).id)] = c;
+                        if ((c as any).parent_id != null) {
+                                const pid = String((c as any).parent_id);
+                                if (!byParent[pid]) parentIds.push(pid);
+                                (byParent[pid] ||= []).push(c);
+                        }
+                }
+                for (const pid in byParent) {
+                        byParent[pid].sort(
+                                (a: any, b: any) => ((a as any).position ?? 0) - ((b as any).position ?? 0)
+                        );
+                }
+                const topLevel = channels
+                        .filter(
+                                (c) =>
+                                        (c as any).parent_id == null &&
+                                        !parentIds.includes(String((c as any).id))
+                        )
+                        .sort(
+                                (a: any, b: any) => ((a as any).position ?? 0) - ((b as any).position ?? 0)
+                        );
+                const categories = parentIds
+                        .map((pid) => ({ cat: idToChannel[pid], items: byParent[pid] ?? [] }))
+                        .sort(
+                                (a, b) =>
+                                        (((a.cat as any)?.position ?? 0) -
+                                                ((b.cat as any)?.position ?? 0))
+                        );
+                return { categories, topLevel };
+        }
 
 	function toggleCollapse(id: string) {
 		collapsed = { ...collapsed, [id]: !collapsed[id] };
@@ -335,119 +431,168 @@
 	>
 		{#if $selectedGuildId}
 			{@const sections = computeSections(currentGuildChannels())}
-			{#if sections.topLevel.length}
-				<div>
-					<div class="px-2 text-xs tracking-wide text-[var(--muted)] uppercase">Uncategorized</div>
-					{#each sections.topLevel.filter((c) => (c.name || '')
-							.toLowerCase()
-							.includes(filter.toLowerCase())) as ch}
-						<div
-							class="group flex cursor-pointer items-center justify-between rounded px-2 py-1 hover:bg-[var(--panel)] {$selectedChannelId ===
-							String((ch as any).id)
-								? 'bg-[var(--panel)]'
-								: ''}"
-							role="button"
-							tabindex="0"
-							onclick={() => selectChannel(String((ch as any).id))}
-							onkeydown={(e) =>
-								(e.key === 'Enter' || e.key === ' ') && selectChannel(String((ch as any).id))}
-							oncontextmenu={(e) => {
-								e.preventDefault();
-								e.stopPropagation();
-								openChannelMenu(e, ch);
-							}}
-						>
-							<div class="flex items-center gap-2 truncate">
-								<span class="opacity-70">#</span>
-								{ch.name}
-							</div>
-							<div
-								class="flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100"
-							>
-								<button
-									class="text-xs text-red-400"
-									title="Delete"
-									onclick={(e) => {
-										e.stopPropagation();
-										deleteChannel(String((ch as any).id));
-									}}>✕</button
-								>
-							</div>
-						</div>
-					{/each}
-				</div>
-			{/if}
-			{#each sections.categories as sec}
-				<div class="mt-2">
-					<div
-						class="flex items-center justify-between px-2 text-xs tracking-wide text-[var(--muted)] uppercase"
-					>
-						<button
-							class="flex items-center gap-2"
-							onclick={() => toggleCollapse(String((sec.cat as any)?.id))}
-						>
-							<span class="inline-block">{collapsed[String((sec.cat as any)?.id)] ? '▸' : '▾'}</span
-							>
-							<div class="truncate">{sec.cat?.name ?? 'Category'}</div>
-						</button>
-						<div class="flex items-center gap-2">
-							<button
-								class="text-xs"
-								title={m.new_channel()}
-								onclick={() => {
-									creatingChannel = true;
-									channelError = null;
-									creatingChannelParent = String((sec.cat as any)?.id);
-								}}>+</button
-							>
-							<button
-								class="text-xs text-red-400"
-								title="Delete category"
-								onclick={() => deleteCategory(String((sec.cat as any)?.id))}>✕</button
-							>
-						</div>
-					</div>
-					{#if !collapsed[String((sec.cat as any)?.id)]}
-						{#each sec.items.filter((c) => (c.name || '')
-								.toLowerCase()
-								.includes(filter.toLowerCase())) as ch}
-							<div
-								class="group flex cursor-pointer items-center justify-between rounded px-2 py-1 hover:bg-[var(--panel)] {$selectedChannelId ===
-								String((ch as any).id)
-									? 'bg-[var(--panel)]'
-									: ''}"
-								role="button"
-								tabindex="0"
-								onclick={() => selectChannel(String((ch as any).id))}
-								onkeydown={(e) =>
-									(e.key === 'Enter' || e.key === ' ') && selectChannel(String((ch as any).id))}
-								oncontextmenu={(e) => {
-									e.preventDefault();
-									e.stopPropagation();
-									openChannelMenu(e, ch);
-								}}
-							>
-								<div class="flex items-center gap-2 truncate">
-									<span class="opacity-70">#</span>
-									{ch.name}
-								</div>
-								<div
-									class="flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100"
-								>
-									<button
-										class="text-xs text-red-400"
-										title="Delete"
-										onclick={(e) => {
-											e.stopPropagation();
-											deleteChannel(String((ch as any).id));
-										}}>✕</button
-									>
-								</div>
-							</div>
-						{/each}
-					{/if}
-				</div>
-			{/each}
+                        {#if sections.topLevel.length}
+                                <div
+                                        ondragover={(e) => {
+                                                e.preventDefault();
+                                                dragOverContainer(null);
+                                        }}
+                                        ondrop={() => dropOnContainer(null)}
+                                        role="list"
+                                >
+                                        {#each sections.topLevel.filter((c) => (c.name || '')
+                                                        .toLowerCase()
+                                                        .includes(filter.toLowerCase())) as ch (String((ch as any).id))}
+                                                <div
+                                                        class="group flex cursor-pointer items-center justify-between rounded px-2 py-1 hover:bg-[var(--panel)] {$selectedChannelId ===
+                                                        String((ch as any).id)
+                                                                ? 'bg-[var(--panel)]'
+                                                                : ''} {dragIndicator?.mode === 'before' && dragIndicator.target === String((ch as any).id) && dragIndicator.parent === null ? 'border-t-2 border-[var(--brand)]' : ''}"
+                                                        role="button"
+                                                        tabindex="0"
+                                                        draggable="true"
+                                                        ondragstart={() => startDrag(ch, null)}
+                                                        ondragover={(e) => {
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                dragOverChannel(String((ch as any).id), null);
+                                                        }}
+                                                        ondrop={(e) => {
+                                                                e.stopPropagation();
+                                                                dropOnChannel(String((ch as any).id), null);
+                                                        }}
+                                                        onclick={() => selectChannel(String((ch as any).id))}
+                                                        onkeydown={(e) =>
+                                                                (e.key === 'Enter' || e.key === ' ') && selectChannel(String((ch as any).id))}
+                                                        oncontextmenu={(e) => {
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                openChannelMenu(e, ch);
+                                                        }}
+                                                >
+                                                        <div class="flex items-center gap-2 truncate">
+                                                                <span class="opacity-70">#</span>
+                                                                {ch.name}
+                                                        </div>
+                                                        <div
+                                                                class="flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100"
+                                                        >
+                                                                <button
+                                                                        class="text-xs text-red-400"
+                                                                        title="Delete"
+                                                                        onclick={(e) => {
+                                                                                e.stopPropagation();
+                                                                                deleteChannel(String((ch as any).id));
+                                                                        }}>✕</button
+                                                                >
+                                                        </div>
+                                                </div>
+                                        {/each}
+                                </div>
+                        {/if}
+                        {#each sections.categories as sec (String((sec.cat as any)?.id))}
+                                <div
+                                        class="mt-2"
+                                        ondragover={(e) => {
+                                                e.preventDefault();
+                                                dragOverContainer(String((sec.cat as any)?.id));
+                                        }}
+                                        ondrop={() => dropOnContainer(String((sec.cat as any)?.id))}
+                                        role="list"
+                                >
+                                        <div
+                                                class="flex items-center justify-between px-2 text-xs tracking-wide text-[var(--muted)] uppercase {dragIndicator?.mode === 'before' && dragIndicator.target === String((sec.cat as any)?.id) && dragIndicator.parent === null ? 'border-t-2 border-[var(--brand)]' : ''} {dragIndicator?.mode === 'inside' && dragIndicator.parent === String((sec.cat as any)?.id) ? 'ring-2 ring-[var(--brand)] rounded-md' : ''}"
+                                                role="button"
+                                                tabindex="0"
+                                                draggable="true"
+                                                ondragstart={() => startDrag(sec.cat, null)}
+                                                ondragover={(e) => {
+                                                        e.preventDefault();
+                                                        e.stopPropagation();
+                                                        if (dragging && dragging.type === 2) {
+                                                                dragOverChannel(String((sec.cat as any)?.id), null);
+                                                        } else {
+                                                                dragOverContainer(String((sec.cat as any)?.id));
+                                                        }
+                                                }}
+                                                ondrop={(e) => {
+                                                        e.stopPropagation();
+                                                        dropOnCategoryHeader(String((sec.cat as any)?.id));
+                                                }}
+                                        >
+                                                <button
+                                                        class="flex items-center gap-2"
+                                                        onclick={() => toggleCollapse(String((sec.cat as any)?.id))}
+                                                >
+                                                        <span class="inline-block">{collapsed[String((sec.cat as any)?.id)] ? '▸' : '▾'}</span>
+                                                        <div class="truncate">{sec.cat?.name ?? 'Category'}</div>
+                                                </button>
+                                                <div class="flex items-center gap-2">
+                                                        <button
+                                                                class="text-xs"
+                                                                title={m.new_channel()}
+                                                                onclick={() => {
+                                                                        creatingChannel = true;
+                                                                        channelError = null;
+                                                                        creatingChannelParent = String((sec.cat as any)?.id);
+                                                                }}>+</button>
+                                                        <button
+                                                                class="text-xs text-red-400"
+                                                                title="Delete category"
+                                                                onclick={() => deleteCategory(String((sec.cat as any)?.id))}>✕</button>
+                                                </div>
+                                        </div>
+                                        {#if !collapsed[String((sec.cat as any)?.id)]}
+                                                {#each sec.items.filter((c) => (c.name || '')
+                                                                .toLowerCase()
+                                                                .includes(filter.toLowerCase())) as ch (String((ch as any).id))}
+                                                        <div
+                                                                class="group flex cursor-pointer items-center justify-between rounded px-2 py-1 hover:bg-[var(--panel)] {$selectedChannelId ===
+                                                                String((ch as any).id)
+                                                                        ? 'bg-[var(--panel)]'
+                                                                        : ''} {dragIndicator?.mode === 'before' && dragIndicator.target === String((ch as any).id) && dragIndicator.parent === String((sec.cat as any)?.id) ? 'border-t-2 border-[var(--brand)]' : ''}"
+                                                                role="button"
+                                                                tabindex="0"
+                                                                draggable="true"
+                                                                ondragstart={() => startDrag(ch, String((sec.cat as any)?.id))}
+                                                                ondragover={(e) => {
+                                                                        e.preventDefault();
+                                                                        e.stopPropagation();
+                                                                        dragOverChannel(String((ch as any).id), String((sec.cat as any)?.id));
+                                                                }}
+                                                                ondrop={(e) => {
+                                                                        e.stopPropagation();
+                                                                        dropOnChannel(String((ch as any).id), String((sec.cat as any)?.id));
+                                                                }}
+                                                                onclick={() => selectChannel(String((ch as any).id))}
+                                                                onkeydown={(e) =>
+                                                                        (e.key === 'Enter' || e.key === ' ') && selectChannel(String((ch as any).id))}
+                                                                oncontextmenu={(e) => {
+                                                                        e.preventDefault();
+                                                                        e.stopPropagation();
+                                                                        openChannelMenu(e, ch);
+                                                                }}
+                                                        >
+                                                                <div class="flex items-center gap-2 truncate">
+                                                                        <span class="opacity-70">#</span>
+                                                                        {ch.name}
+                                                                </div>
+                                                                <div
+                                                                        class="flex items-center gap-2 opacity-0 transition-opacity group-hover:opacity-100"
+                                                                >
+                                                                        <button
+                                                                                class="text-xs text-red-400"
+                                                                                title="Delete"
+                                                                                onclick={(e) => {
+                                                                                        e.stopPropagation();
+                                                                                        deleteChannel(String((ch as any).id));
+                                                                                }}>✕</button>
+                                                                </div>
+                                                        </div>
+                                                {/each}
+                                        {/if}
+                                </div>
+                        {/each}
 		{:else}
 			<div class="p-4 text-sm text-[var(--muted)]">Select a server to view channels.</div>
 		{/if}


### PR DESCRIPTION
## Summary
- refresh JWTs using stored refresh token
- drag and drop channels and categories with highlight cues and updated reorder API

## Testing
- `npm run lint` *(warnings: Code style issues found in 15 files)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c75844ae788322a45977db7451849a