### PR TITLE
feat: add landing page container build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,8 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image name
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - name: Set image names
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+          echo "LANDING_IMAGE_NAME=${GITHUB_REPOSITORY,,}-landing" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -39,6 +41,18 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:dev
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push landing dev image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./landing
+          file: ./landing/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.LANDING_IMAGE_NAME }}:dev
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.component=landing
             org.opencontainers.image.revision=${{ github.sha }}
 
   semantic_release:
@@ -81,8 +95,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set image name
-        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - name: Set image names
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+          echo "LANDING_IMAGE_NAME=${GITHUB_REPOSITORY,,}-landing" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -99,5 +115,19 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.semantic_release.outputs.version }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.semantic_release.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Build and push landing release image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./landing
+          file: ./landing/Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.LANDING_IMAGE_NAME }}:${{ needs.semantic_release.outputs.version }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.component=landing
             org.opencontainers.image.version=${{ needs.semantic_release.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/landing/Dockerfile
+++ b/landing/Dockerfile
@@ -1,0 +1,9 @@
+# syntax=docker/dockerfile:1
+
+FROM nginx:alpine
+
+# Copy the static landing page into the default nginx html directory
+COPY index.html /usr/share/nginx/html/index.html
+
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add an nginx-based Dockerfile in `landing/` to serve the static landing page
- extend the container CI workflow to build and push landing images for dev and release branches

## Testing
- npm run lint *(fails: repository contains existing formatting issues reported by Prettier)*
- npm run check *(fails: existing bigint typing errors in auth forms)*
- npm run build *(fails: missing dependency highlight.js/lib/common in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68cb95a91f8c8322b015c0516025c296