### PR TITLE
fix: support sub-path static deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ PUBLIC_WS_URL=
 # PUBLIC_WS_URL=localhost/ws/subscribe
 # PUBLIC_WS_URL=api.example.com/ws/subscribe
 
+PUBLIC_BASE_PATH=
+
+# Optional path prefix if the UI is served from a subdirectory (e.g. `/app` behind Traefik).
+# Set this before running `npm run build` so static assets emit under `<prefix>/_app`.
+# Examples:
+# PUBLIC_BASE_PATH=/app
+# PUBLIC_BASE_PATH=/gochat
+
 PUBLIC_API_BASE_URL=
 
 # Examples:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,15 @@
 # Build stage
 FROM node:20-alpine AS build
 WORKDIR /app
+
+# Allow overriding public env vars (used at build-time for the static output)
+ARG PUBLIC_BASE_PATH=""
+ARG PUBLIC_API_BASE_URL=""
+ARG PUBLIC_WS_URL=""
+ENV PUBLIC_BASE_PATH=${PUBLIC_BASE_PATH}
+ENV PUBLIC_API_BASE_URL=${PUBLIC_API_BASE_URL}
+ENV PUBLIC_WS_URL=${PUBLIC_WS_URL}
+
 COPY package*.json ./
 RUN npm ci
 COPY . .

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A SvelteKit-based UI for the GoChat service. The project uses Svelte 5, TypeScript and Tailwind CSS to deliver a modern chat experience with real-time updates.
 
 ## Features
+
 - Channels and direct messages
 - REST and WebSocket clients
 - Internationalisation with Paraglide
@@ -11,54 +12,82 @@ A SvelteKit-based UI for the GoChat service. The project uses Svelte 5, TypeScri
 ## Getting Started
 
 ### Prerequisites
+
 - Node.js 20+
 - npm
 
 ### Installation
+
 ```bash
 npm install
 ```
 
 Copy `.env.example` to `.env` and set the required environment variables:
+
 ```env
 PUBLIC_WS_URL=
+PUBLIC_BASE_PATH=
 PUBLIC_API_BASE_URL=
 ```
 
+- `PUBLIC_WS_URL` — websocket endpoint for real-time updates.
+- `PUBLIC_BASE_PATH` — optional path prefix when serving the UI from a subdirectory (e.g. `/app`). Set this before running `npm run build` so the static output emits assets under `<prefix>/_app`.
+- `PUBLIC_API_BASE_URL` — base URL for REST API calls from the browser.
+
 ### Development
+
 Start the development server:
+
 ```bash
 npm run dev
 ```
 
 Run linting and type checks:
+
 ```bash
 npm run lint
 npm run check
 ```
 
 ### Building
+
 Create an optimized production build:
+
 ```bash
 npm run build
 ```
+
 Preview the built app locally:
+
 ```bash
 npm run preview
 ```
 
 ## Docker
+
 The repository includes a multi-stage `Dockerfile` that builds the static site and serves it with Nginx.
 
 Build the image:
+
 ```bash
-docker build -t gochatui .
+docker build \
+  --build-arg PUBLIC_BASE_PATH=/app \
+  -t gochatui .
 ```
+
 Run the container:
+
 ```bash
 docker run -p 3000:80 gochatui
 ```
+
 The application will be available at http://localhost:3000.
 
+When deploying behind a reverse proxy that only forwards a sub-path (for example Traefik routing `/app` to the UI container), ensure that:
+
+- `PUBLIC_BASE_PATH` is set to the forwarded prefix **at build time**.
+- The proxy forwards both `/app` and `/app/_app/*` to the UI container so static assets resolve correctly. The provided `nginx.conf` already serves `/app` with an SPA fallback to `/app/index.html` for deep links.
+
 ## License
+
 This project is proprietary and does not yet specify a license.

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,14 @@ server {
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+    location = /app {
+        try_files $uri $uri/ /app/index.html;
+    }
+
+    location /app/ {
+        try_files $uri $uri.html $uri/ /app/index.html;
+    }
+
     location / {
         try_files $uri $uri.html $uri/ /index.html;
     }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,12 +1,34 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+const dev = process.argv.includes('dev');
+
+function normalizeBasePath(path) {
+	if (!path) return '';
+	let normalized = path.trim();
+	if (!normalized || normalized === '/') return '';
+	if (!normalized.startsWith('/')) normalized = `/${normalized}`;
+	return normalized.replace(/\/+$/, '');
+}
+
+const basePath = normalizeBasePath(process.env.PUBLIC_BASE_PATH);
+const assetOutDir = basePath ? `build${basePath}` : 'build';
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
-	kit: { adapter: adapter({ strict: false }) }
+        kit: {
+                adapter: adapter({
+                        strict: false,
+                        assets: assetOutDir
+                }),
+                paths: {
+                        base: '',
+                        assets: dev ? '' : basePath
+                }
+        }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- write adapter-static assets under the optional PUBLIC_BASE_PATH and configure Svelte paths so builds work behind reverse-proxy prefixes
- allow docker builds to receive PUBLIC_* arguments and update nginx to serve /app with an SPA fallback
- document the PUBLIC_BASE_PATH workflow in the README and sample environment file for sub-directory deployments

## Testing
- `npm run lint` *(fails: existing Prettier warnings across unrelated files)*
- `npm run check` *(fails: existing bigint typing errors in auth forms)*
- `npm run build` *(fails: existing missing dependency highlight.js/lib/common during Vite build)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb4c93bb4832281dd1193361e5ee0