### PR TITLE
fix: respect base path for static builds

### DIFF
--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -1,1 +1,5 @@
-<a href="/demo/paraglide">paraglide</a>
+<script>
+	import { base } from '$app/paths';
+</script>
+
+<a href={`${base}/demo/paraglide`}>paraglide</a>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -19,16 +19,17 @@ const config = {
 	// Consult https://svelte.dev/docs/kit/integrations
 	// for more information about preprocessors
 	preprocess: vitePreprocess(),
-        kit: {
-                adapter: adapter({
-                        strict: false,
-                        assets: assetOutDir
-                }),
-                paths: {
-                        base: '',
-                        assets: dev ? '' : basePath
-                }
-        }
+	kit: {
+		adapter: adapter({
+			strict: false,
+			assets: assetOutDir
+		}),
+		paths: {
+			base: dev ? '' : basePath,
+			assets: '',
+			relative: basePath ? false : true
+		}
+	}
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- derive `kit.paths.base` from the normalized `PUBLIC_BASE_PATH` in production builds and disable relative asset paths when a prefix is present so emitted HTML references `<basePath>/_app`
- keep adapter-static assets in the same prefixed folder to match the generated URLs
- update the demo page link to use `$app/paths.base`, ensuring client-side navigation honors the configured base path

## Testing
- PUBLIC_BASE_PATH=/app npm run build
- npm run check
- npm run build
- npx --yes serve@14.2.5 build -l 4173 -s (manual smoke test via curl)


------
https://chatgpt.com/codex/tasks/task_e_68cbdd74757483228372e854031e49bf