### PR TITLE
feat: move app route under /app and add landing page

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -2,6 +2,12 @@
 @plugin '@tailwindcss/forms';
 @plugin '@tailwindcss/typography';
 
+@theme {
+	--color-ink-900: #09090b;
+	--color-ink-800: #0b0b0f;
+	--shadow-chrome: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
 :root {
 	--radius-lg: 16px;
 	--radius-md: 12px;
@@ -56,11 +62,13 @@
 	color-scheme: light;
 }
 
-html,
+html {
+	height: 100%;
+	scroll-behavior: smooth;
+}
+
 body {
 	height: 100%;
-}
-body {
 	margin: 0;
 	font-family:
 		Inter,
@@ -72,9 +80,11 @@ body {
 		Arial,
 		'Apple Color Emoji',
 		'Segoe UI Emoji';
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 	color: var(--text);
 	background: var(--bg);
-	overflow: hidden;
+	overflow: auto;
 }
 
 .panel {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,67 +1,445 @@
 <script lang="ts">
-	import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
-	import ServerBar from '$lib/components/app/sidebar/ServerBar.svelte';
-	import ChannelPane from '$lib/components/app/sidebar/ChannelPane.svelte';
-	import ChatPane from '$lib/components/app/chat/ChatPane.svelte';
-	import SearchPanel from '$lib/components/app/search/SearchPanel.svelte';
-	import DmCreate from '$lib/components/app/dm/DmCreate.svelte';
-	import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
-	import ContextMenu from '$lib/components/ui/ContextMenu.svelte';
-	import { searchOpen } from '$lib/stores/appState';
-	import '$lib/client/ws';
-	import { m } from '$lib/paraglide/messages.js';
-
-	let showProfile = false;
+	const currentYear = new Date().getFullYear();
 </script>
 
-<AuthGate>
-	<div class="grid h-screen w-screen" style="grid-template-columns: var(--col1) var(--col2) 1fr;">
-		<ServerBar />
-		<div class="flex h-full min-h-0 flex-col overflow-hidden">
-			<div
-				class="box-border flex h-[var(--header-h)] flex-shrink-0 items-center justify-between overflow-hidden border-b border-[var(--stroke)] px-3"
-			>
-				<div class="flex items-center gap-2">
-					<DmCreate />
-				</div>
-				<div class="flex items-center gap-2">
-					<button
-						class="grid h-8 w-8 place-items-center rounded-md border border-[var(--stroke)] hover:bg-[var(--panel)]"
-						on:click={() => (showProfile = !showProfile)}
-						title={m.profile()}
-						aria-label={m.profile()}
+<svelte:head>
+	<title>GoChat — Fast, clean, open-source chat</title>
+	<meta
+		name="description"
+		content="GoChat is a sleek, open-source Discord-style chat service with channels, mentions and instant real-time messaging. Voice & video coming soon."
+	/>
+</svelte:head>
+
+<div id="top" class="relative isolate min-h-screen bg-ink-900 text-zinc-200">
+	<div
+		class="pointer-events-none fixed inset-0 -z-10 [mask-image:radial-gradient(50%_50%_at_50%_40%,black_20%,transparent_70%)]"
+	>
+		<div
+			class="absolute -top-24 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-600/20 blur-3xl"
+		></div>
+		<div class="absolute top-64 right-12 h-72 w-72 rounded-full bg-indigo-600/20 blur-3xl"></div>
+		<div class="absolute bottom-12 left-10 h-64 w-64 rounded-full bg-fuchsia-600/10 blur-3xl"></div>
+	</div>
+
+	<header class="sticky top-0 z-50 border-b border-white/10 bg-ink-900/70 backdrop-blur">
+		<div class="mx-auto flex h-16 max-w-7xl items-center justify-between px-6 sm:px-8">
+			<a href="/" class="flex items-center gap-2">
+				<span class="inline-block h-7 w-7 rounded bg-gradient-to-tr from-violet-500 to-fuchsia-500"
+				></span>
+				<span class="text-sm font-semibold tracking-wide">GoChat</span>
+				<span
+					class="ml-2 hidden rounded-md border border-white/10 bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-300 sm:inline"
+					>Open-source</span
+				>
+			</a>
+			<nav class="hidden items-center gap-6 text-sm text-zinc-300 sm:flex">
+				<a class="hover:text-white" href="#features">Features</a>
+				<a class="hover:text-white" href="#preview">Preview</a>
+				<a class="hover:text-white" href="#cta">Get Started</a>
+			</nav>
+			<div class="flex items-center gap-2">
+				<a
+					href="https://github.com/FlameInTheDark/gochat"
+					target="_blank"
+					rel="noopener"
+					class="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/10 bg-white/5 hover:bg-white/10"
+					aria-label="GitHub repository"
+				>
+					<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" class="text-zinc-200">
+						<path
+							fill-rule="evenodd"
+							clip-rule="evenodd"
+							d="M12 .5a11.5 11.5 0 0 0-3.64 22.42c.58.11.79-.25.79-.56v-2.06c-3.2.7-3.87-1.39-3.87-1.39-.53-1.34-1.3-1.7-1.3-1.7-1.06-.73.08-.72.08-.72 1.17.08 1.79 1.21 1.79 1.21 1.04 1.79 2.74 1.27 3.41.97.11-.76.41-1.27.75-1.56-2.55-.29-5.23-1.28-5.23-5.68 0-1.26.45-2.29 1.2-3.09-.12-.29-.52-1.45.11-3.03 0 0 .98-.31 3.22 1.18a11.2 11.2 0 0 1 5.86 0c2.23-1.49 3.21-1.18 3.21-1.18.64 1.58.24 2.74.12 3.03.75.8 1.2 1.83 1.2 3.09 0 4.41-2.69 5.38-5.25 5.66.42.36.8 1.06.8 2.14v3.17c0 .31.21.68.8.56A11.5 11.5 0 0 0 12 .5Z"
+						/>
+					</svg>
+				</a>
+				<a
+					href="/app"
+					class="rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white hover:bg-violet-500"
+					>Open App</a
+				>
+			</div>
+		</div>
+	</header>
+
+	<main>
+		<section
+			class="mx-auto grid max-w-7xl grid-cols-1 items-center gap-10 px-6 py-16 sm:px-8 md:grid-cols-2 md:py-24"
+		>
+			<div>
+				<h1 class="text-4xl font-black tracking-tight sm:text-5xl">
+					Conversations that feel instant.
+					<span
+						class="block bg-gradient-to-r from-violet-400 via-fuchsia-400 to-indigo-400 bg-clip-text text-transparent"
+						>Built for communities and teams.</span
 					>
+				</h1>
+				<p class="mt-5 max-w-xl text-base leading-relaxed text-zinc-400">
+					GoChat is a sleek, open-source chat service with channels, mentions, and blazing-fast
+					real-time messaging. Voice & video arrive soon — the foundation is already here.
+				</p>
+				<div class="mt-6 flex flex-wrap items-center gap-3">
+					<a
+						href="https://github.com/FlameInTheDark/gochat"
+						target="_blank"
+						rel="noopener"
+						class="rounded-xl border border-violet-500/40 bg-violet-600/90 px-5 py-3 text-base font-medium text-white hover:bg-violet-500"
+						>View on GitHub</a
+					>
+					<a
+						href="/app"
+						class="rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-base text-zinc-200 hover:bg-white/10"
+						>Live preview</a
+					>
+					<span class="ml-2 flex items-center gap-2 text-xs text-zinc-400">
 						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							viewBox="0 0 24 24"
 							width="16"
 							height="16"
-							fill="currentColor"
-							><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10z" /><path
-								d="M4 20a8 8 0 0 1 16 0v1H4v-1z"
-							/></svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="opacity-80"
 						>
-					</button>
+							<polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon>
+						</svg>
+						No installs • Works in the browser
+					</span>
 				</div>
 			</div>
-			<ChannelPane />
-		</div>
-		<ChatPane />
-		<SearchPanel />
-		{#if showProfile}
-			<div class="fixed top-20 right-4 z-40">
-				<ProfileEdit />
-			</div>
-		{/if}
-	</div>
-	<ContextMenu />
-</AuthGate>
 
-<svelte:window
-	on:keydown={(e) => {
-		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
-			e.preventDefault();
-			searchOpen.set(true);
-		}
-	}}
-/>
+			<div id="preview" class="relative">
+				<div
+					class="relative h-[560px] w-full overflow-hidden rounded-2xl border border-white/10 bg-zinc-900 shadow-chrome"
+				>
+					<div
+						class="absolute inset-0 bg-[radial-gradient(80%_60%_at_10%_0%,rgba(139,92,246,0.08),transparent_50%),radial-gradient(60%_50%_at_90%_100%,rgba(99,102,241,0.08),transparent_50%)]"
+					></div>
+
+					<div class="relative z-10 grid h-full grid-cols-[72px_240px_1fr]">
+						<aside
+							class="flex flex-col items-center gap-3 border-r border-white/10 bg-ink-800/60 p-3"
+						>
+							<span class="h-10 w-10 rounded-2xl bg-gradient-to-tr from-violet-500 to-fuchsia-500"
+							></span>
+							<span class="h-10 w-10 rounded-2xl bg-zinc-800"></span>
+							<span class="h-10 w-10 rounded-2xl bg-zinc-800"></span>
+							<span class="h-10 w-10 rounded-2xl bg-zinc-800"></span>
+							<span class="h-10 w-10 rounded-2xl bg-zinc-800"></span>
+							<span class="h-10 w-10 rounded-2xl bg-zinc-800"></span>
+							<span class="mt-auto h-10 w-10 rounded-2xl border border-white/10 bg-white/5"></span>
+						</aside>
+
+						<aside class="flex flex-col gap-3 border-r border-white/10 bg-ink-800/30 p-3">
+							<div class="h-8 rounded-lg border border-white/10 bg-white/5"></div>
+							<div class="space-y-2">
+								<div class="h-7 rounded-full bg-white/5"></div>
+								<div class="h-7 rounded-full bg-white/5"></div>
+								<div class="h-7 rounded-full bg-white/5"></div>
+								<div class="h-7 rounded-full bg-white/5"></div>
+								<div class="h-7 rounded-full bg-white/5"></div>
+								<div class="h-7 rounded-full bg-white/5"></div>
+							</div>
+							<div class="mt-auto h-9 rounded-lg border border-white/10 bg-white/5"></div>
+						</aside>
+
+						<main class="relative flex min-w-0 flex-col">
+							<div
+								class="flex h-12 items-center gap-2 border-b border-white/10 bg-zinc-900/70 px-3"
+							>
+								<div class="h-6 w-24 rounded bg-white/5"></div>
+								<div
+									class="ml-auto hidden h-7 w-48 rounded-lg border border-white/10 bg-white/5 sm:block"
+								></div>
+								<div class="h-7 w-16 rounded-lg border border-white/10 bg-white/5"></div>
+							</div>
+
+							<div class="relative flex-1 overflow-hidden">
+								<div class="absolute inset-0 space-y-4 overflow-y-auto p-4 sm:p-6">
+									<div class="flex items-start gap-3">
+										<span class="h-8 w-8 shrink-0 rounded-lg bg-zinc-800"></span>
+										<div class="flex-1 space-y-2">
+											<div class="h-3 w-24 rounded bg-white/10"></div>
+											<div class="h-3 w-3/4 rounded bg-white/5"></div>
+											<div class="h-3 w-2/3 rounded bg-white/5"></div>
+										</div>
+									</div>
+									<div class="flex items-start gap-3">
+										<span class="h-8 w-8 shrink-0 rounded-lg bg-zinc-800"></span>
+										<div class="flex-1 space-y-2">
+											<div class="h-3 w-20 rounded bg-white/10"></div>
+											<div class="h-3 w-1/2 rounded bg-white/5"></div>
+											<div class="h-3 w-2/5 rounded bg-white/5"></div>
+										</div>
+									</div>
+									<div class="flex items-start gap-3">
+										<span class="h-8 w-8 shrink-0 rounded-lg bg-zinc-800"></span>
+										<div class="flex-1 space-y-2">
+											<div class="h-3 w-28 rounded bg-white/10"></div>
+											<div class="h-3 w-4/5 rounded bg-white/5"></div>
+											<div class="h-3 w-1/2 rounded bg-white/5"></div>
+										</div>
+									</div>
+									<div class="rounded-xl border border-white/10 bg-ink-900/60 p-4">
+										<div class="h-3 w-1/3 rounded bg-white/10"></div>
+										<div class="mt-2 h-3 w-2/3 rounded bg-white/5"></div>
+									</div>
+								</div>
+
+								<div class="absolute inset-x-0 bottom-0 border-t border-white/10 bg-ink-900/70 p-3">
+									<div
+										class="mx-auto flex max-w-2xl items-center gap-2 rounded-xl border border-white/10 bg-zinc-900/80 px-3 py-2"
+									>
+										<span class="h-5 w-5 rounded bg-zinc-800"></span>
+										<div class="h-6 flex-1 rounded bg-white/5"></div>
+										<div class="h-8 w-20 rounded-lg bg-violet-600/80"></div>
+									</div>
+								</div>
+							</div>
+						</main>
+					</div>
+
+					<span class="pointer-events-none absolute inset-0 rounded-2xl ring-1 ring-white/5"></span>
+				</div>
+			</div>
+		</section>
+
+		<section id="features" class="mx-auto max-w-7xl px-6 py-16 sm:px-8 sm:py-24">
+			<div class="mx-auto mb-10 max-w-2xl text-center">
+				<span
+					class="mb-3 inline-block rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-300"
+					>What you get</span
+				>
+				<h2 class="text-3xl font-bold tracking-tight sm:text-4xl">
+					All the essentials, beautifully done
+				</h2>
+				<p class="mt-3 text-zinc-400">
+					A focused chat experience that echoes the in-app look and feel — without copying it.
+				</p>
+			</div>
+
+			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"></path>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Real-time channels</span>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Organize conversations by topic. Mentions, replies, and link previews keep context
+						tight.
+					</p>
+				</div>
+
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<circle cx="11" cy="11" r="8"></circle>
+							<line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Fast global search</span>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Find messages, links, and files instantly across all channels.
+					</p>
+				</div>
+
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Roles & permissions</span>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Fine-grained control with bitmask roles (owner, admin, mod, member).
+					</p>
+				</div>
+
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path d="M18 8a6 6 0 10-12 0c0 7-3 9-3 9h18s-3-2-3-9"></path>
+							<path d="M13.73 21a2 2 0 01-3.46 0"></path>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Smart notifications</span>
+						<span
+							class="ml-2 rounded-md border border-violet-500/30 bg-violet-500/10 px-1.5 py-0.5 text-[10px] text-violet-200"
+							>Coming soon</span
+						>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Noise-aware alerts so you never miss the important stuff.
+					</p>
+				</div>
+
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+							<path d="M7 11V7a5 5 0 0110 0v4"></path>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Secure by default</span>
+						<span
+							class="ml-2 rounded-md border border-violet-500/30 bg-violet-500/10 px-1.5 py-0.5 text-[10px] text-violet-200"
+							>Coming soon</span
+						>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Encrypted transport and role-based access keep your data safe.
+					</p>
+				</div>
+
+				<div class="h-full rounded-2xl border border-white/10 bg-ink-900/70 p-5">
+					<div
+						class="mb-3 inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+					>
+						<svg
+							width="18"
+							height="18"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+						>
+							<path
+								d="M22 16.92v3a2 2 0 0 1-2.18 2 19.8 19.8 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.8 19.8 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72 12.66 12.66 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.66 12.66 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"
+							></path>
+						</svg>
+						<span class="text-sm font-semibold text-zinc-100">Voice & video</span>
+						<span
+							class="ml-2 rounded-md border border-violet-500/30 bg-violet-500/10 px-1.5 py-0.5 text-[10px] text-violet-200"
+							>Coming soon</span
+						>
+					</div>
+					<p class="text-sm leading-relaxed text-zinc-400">
+						Crystal-clear calls with screen share will land next.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<section id="cta" class="mx-auto max-w-7xl px-6 pb-20 sm:px-8">
+			<div class="rounded-2xl border border-white/10 bg-ink-900/70 p-6 sm:p-8">
+				<div class="grid items-center gap-6 md:grid-cols-2">
+					<div>
+						<h3 class="text-xl font-semibold">Feels familiar, stays original</h3>
+						<p class="mt-2 text-sm text-zinc-400">
+							The landing page mirrors the product’s mood — dark palette, soft glass, and tidy
+							layout — without duplicating the interface.
+						</p>
+						<div class="mt-4 flex flex-wrap items-center gap-3 text-xs text-zinc-300">
+							<span class="rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+								>Dark mode first</span
+							>
+							<span class="rounded-lg border border-white/10 bg-white/5 px-2 py-1"
+								>Keyboard friendly</span
+							>
+							<span class="rounded-lg border border-white/10 bg-white/5 px-2 py-1">Responsive</span>
+						</div>
+					</div>
+					<div class="flex flex-wrap items-center gap-3 md:justify-end">
+						<a
+							href="/app"
+							class="rounded-xl bg-violet-600 px-5 py-3 text-base font-medium text-white hover:bg-violet-500"
+							>Open App</a
+						>
+						<a
+							href="https://github.com/FlameInTheDark/gochat"
+							target="_blank"
+							rel="noopener"
+							class="rounded-xl border border-white/10 bg-white/5 px-5 py-3 text-base text-zinc-200 hover:bg-white/10"
+							>View on GitHub</a
+						>
+					</div>
+				</div>
+			</div>
+		</section>
+	</main>
+
+	<footer class="border-t border-white/10 py-10">
+		<div
+			class="mx-auto flex max-w-7xl flex-col items-center justify-between gap-6 px-6 sm:flex-row sm:px-8"
+		>
+			<div class="flex items-center gap-2">
+				<span class="inline-block h-6 w-6 rounded bg-gradient-to-tr from-violet-500 to-fuchsia-500"
+				></span>
+				<span class="text-sm font-semibold">GoChat</span>
+				<span class="ml-2 text-xs text-zinc-400">© {currentYear}</span>
+			</div>
+			<p class="text-center text-xs text-zinc-500 sm:text-right">
+				Open-source chat for communities that love clean, fast messaging.
+			</p>
+			<nav class="flex items-center gap-4 text-sm text-zinc-400">
+				<a class="hover:text-white" href="#features">Features</a>
+				<a class="hover:text-white" href="#preview">Preview</a>
+				<a
+					class="hover:text-white"
+					href="https://github.com/FlameInTheDark/gochat/actions"
+					target="_blank"
+					rel="noopener">Status</a
+				>
+			</nav>
+		</div>
+	</footer>
+</div>

--- a/src/routes/app/+layout.svelte
+++ b/src/routes/app/+layout.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { children } = $props();
+</script>
+
+<svelte:head>
+	<style>
+		body {
+			overflow: hidden;
+		}
+	</style>
+</svelte:head>
+
+{@render children?.()}

--- a/src/routes/app/AppPage.svelte
+++ b/src/routes/app/AppPage.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
+	import ServerBar from '$lib/components/app/sidebar/ServerBar.svelte';
+	import ChannelPane from '$lib/components/app/sidebar/ChannelPane.svelte';
+	import ChatPane from '$lib/components/app/chat/ChatPane.svelte';
+	import SearchPanel from '$lib/components/app/search/SearchPanel.svelte';
+	import DmCreate from '$lib/components/app/dm/DmCreate.svelte';
+	import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
+	import ContextMenu from '$lib/components/ui/ContextMenu.svelte';
+	import { searchOpen } from '$lib/stores/appState';
+	import '$lib/client/ws';
+	import { m } from '$lib/paraglide/messages.js';
+
+	let showProfile = false;
+</script>
+
+<AuthGate>
+	<div class="grid h-screen w-screen" style="grid-template-columns: var(--col1) var(--col2) 1fr;">
+		<ServerBar />
+		<div class="flex h-full min-h-0 flex-col overflow-hidden">
+			<div
+				class="box-border flex h-[var(--header-h)] flex-shrink-0 items-center justify-between overflow-hidden border-b border-[var(--stroke)] px-3"
+			>
+				<div class="flex items-center gap-2">
+					<DmCreate />
+				</div>
+				<div class="flex items-center gap-2">
+					<button
+						class="grid h-8 w-8 place-items-center rounded-md border border-[var(--stroke)] hover:bg-[var(--panel)]"
+						on:click={() => (showProfile = !showProfile)}
+						title={m.profile()}
+						aria-label={m.profile()}
+					>
+						<svg
+							xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							width="16"
+							height="16"
+							fill="currentColor"
+							><path d="M12 12a5 5 0 1 0 0-10 5 5 0 0 0 0 10z" /><path
+								d="M4 20a8 8 0 0 1 16 0v1H4v-1z"
+							/>
+						</svg>
+					</button>
+				</div>
+			</div>
+			<ChannelPane />
+		</div>
+		<ChatPane />
+		<SearchPanel />
+		{#if showProfile}
+			<div class="fixed top-20 right-4 z-40">
+				<ProfileEdit />
+			</div>
+		{/if}
+	</div>
+	<ContextMenu />
+</AuthGate>
+
+<svelte:window
+	on:keydown={(e) => {
+		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+			e.preventDefault();
+			searchOpen.set(true);
+		}
+	}}
+/>

--- a/src/routes/app/[...path]/+page.svelte
+++ b/src/routes/app/[...path]/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import AppPage from '../AppPage.svelte';
+</script>
+
+<AppPage />

--- a/src/routes/confirmation/[userId]/[token]/+page.svelte
+++ b/src/routes/confirmation/[userId]/[token]/+page.svelte
@@ -1,24 +1,20 @@
 <script lang="ts">
-        import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
-        import type { PageData } from './$types';
+	import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
+	import type { PageData } from './$types';
 
-        let { data } = $props<{ data: PageData }>();
+	let { data } = $props<{ data: PageData }>();
 
-        let confirmDefaults = $state({
-                id: data.userId,
-                token: data.token
-        });
+	let confirmDefaults = $state({
+		id: data.userId,
+		token: data.token
+	});
 
-        $effect(() => {
-                confirmDefaults = {
-                        id: data.userId,
-                        token: data.token
-                };
-        });
+	$effect(() => {
+		confirmDefaults = {
+			id: data.userId,
+			token: data.token
+		};
+	});
 </script>
 
-<AuthGate
-        initialMode="confirm"
-        confirmDefaults={confirmDefaults}
-        redirectTo="/"
-/>
+<AuthGate initialMode="confirm" {confirmDefaults} redirectTo="/app" />


### PR DESCRIPTION
## Summary
- move the authenticated chat UI into `src/routes/app` with a catch-all page so `/app` and `/app/...` share the same shell, and add a local layout to keep the body scroll locked while in the app
- rebuild the root `/` route as a marketing landing page that ports the Tailwind-based markup from `landing/index.html` and updates links toward the new `/app` location
- extend the Tailwind theme with the `ink` palette/shadow used by the landing page and update confirmation redirects to point to `/app`

## Testing
- npm run lint *(fails: repository already contains Prettier formatting differences in many existing files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbe3eed5d8832290288f909bbc2350