### PR TITLE
fix: serve chat UI under app path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,5 +21,8 @@ RUN npm run build
 FROM nginx:alpine AS production
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/build /usr/share/nginx/html
+RUN mkdir -p /usr/share/nginx/html/app \
+    && mv /usr/share/nginx/html/app.html /usr/share/nginx/html/app/index.html \
+    && cp -r /usr/share/nginx/html/_app /usr/share/nginx/html/app/_app
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,11 +4,11 @@ server {
     root /usr/share/nginx/html;
     index index.html;
     location = /app {
-        return 301 /;
+        try_files /app/index.html =404;
     }
 
-    location ~ ^/app/(.*)$ {
-        return 301 /$1;
+    location /app/ {
+        try_files $uri $uri/ /app/index.html;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- update nginx to serve the chat build from /app without redirects while leaving the landing page at /
- reorganize the Docker image to place the SvelteKit output under /app alongside the landing assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc99ea95748322bbd67810d763e5e4