### PR TITLE
feat: add runtime environment config support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,14 @@ RUN npm run build
 
 # Production stage
 FROM nginx:alpine AS production
+RUN apk add --no-cache jq
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/build /usr/share/nginx/html
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 RUN mkdir -p /usr/share/nginx/html/app \
     && mv /usr/share/nginx/html/app.html /usr/share/nginx/html/app/index.html \
     && cp -r /usr/share/nginx/html/_app /usr/share/nginx/html/app/_app
 EXPOSE 80
+ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ docker run -p 3000:80 gochatui
 
 The application will be available at http://localhost:3000.
 
+### Runtime configuration
+
+At container start an entrypoint script writes `/usr/share/nginx/html/runtime-env.js` with the values of `PUBLIC_API_BASE_URL`, `PUBLIC_WS_URL` and `PUBLIC_BASE_PATH`. The page includes this script before the Svelte bundle loads, so browser code can discover deployment-specific endpoints without rebuilding the image.
+
+- Leave a variable unset (or empty) to fall back to the build-time value baked into the static bundle.
+- Override the defaults by passing environment variables to `docker run` (or your orchestrator):
+
+  ```bash
+  docker run -p 3000:80 \
+    -e PUBLIC_API_BASE_URL=https://api.example.com/v1 \
+    -e PUBLIC_WS_URL=wss://ws.example.com/subscribe \
+    -e PUBLIC_BASE_PATH=/app \
+    gochatui
+  ```
+
+The generated script is served as a static asset (`/runtime-env.js`), so the configuration is cached by browsers and CDNs just like other files. Restart the container after changing environment variables to refresh the runtime configuration.
+
 When deploying behind a reverse proxy that only forwards a sub-path, ensure that:
 
 - `PUBLIC_BASE_PATH` is set to the forwarded prefix **at build time**.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+OUTPUT="/usr/share/nginx/html/runtime-env.js"
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+api_json=$(printf '%s' "${PUBLIC_API_BASE_URL-}" | jq -R .)
+ws_json=$(printf '%s' "${PUBLIC_WS_URL-}" | jq -R .)
+base_path_json=$(printf '%s' "${PUBLIC_BASE_PATH-}" | jq -R .)
+
+cat <<RUNTIME_EOF > "$OUTPUT"
+window.__RUNTIME_CONFIG__ = {
+  PUBLIC_BASE_PATH: ${base_path_json},
+  PUBLIC_API_BASE_URL: ${api_json},
+  PUBLIC_WS_URL: ${ws_json}
+};
+RUNTIME_EOF
+
+exec "$@"

--- a/src/app.html
+++ b/src/app.html
@@ -7,6 +7,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 		<link href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css" rel="stylesheet" />
+		<script src="/runtime-env.js" defer></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/client/api.ts
+++ b/src/lib/client/api.ts
@@ -10,6 +10,7 @@ import {
 } from '$lib/api';
 import axios, { type AxiosInstance } from 'axios';
 import { env as publicEnv } from '$env/dynamic/public';
+import { getRuntimeConfig } from '$lib/runtime/config';
 
 // Stringify payloads so bigint values emit as int64 numbers instead of quoted strings
 function stringifyBigInt(data: unknown): string {
@@ -32,12 +33,17 @@ export type ApiGroup = {
 };
 
 function computeApiBase(): string {
-	const configured = (publicEnv?.PUBLIC_API_BASE_URL as string | undefined) || undefined;
-	if (configured && configured.trim().length > 0) {
-		return configured.replace(/\/+$/, '');
-	}
-	// Fallback: explicit localhost for both browser and SSR to avoid relying on a dev proxy
-	return 'http://localhost/api/v1';
+        const runtime = getRuntimeConfig();
+        const runtimeConfigured = runtime?.PUBLIC_API_BASE_URL?.trim();
+        if (runtimeConfigured && runtimeConfigured.length > 0) {
+                return runtimeConfigured.replace(/\/+$/, '');
+        }
+        const configured = ((publicEnv?.PUBLIC_API_BASE_URL as string | undefined) || undefined)?.trim();
+        if (configured && configured.length > 0) {
+                return configured.replace(/\/+$/, '');
+        }
+        // Fallback: explicit localhost for both browser and SSR to avoid relying on a dev proxy
+        return 'http://localhost/api/v1';
 }
 
 export function createApi(

--- a/src/lib/client/ws.ts
+++ b/src/lib/client/ws.ts
@@ -3,6 +3,7 @@ import { auth } from '$lib/stores/auth';
 import { selectedChannelId, selectedGuildId } from '$lib/stores/appState';
 import { browser } from '$app/environment';
 import { env as publicEnv } from '$env/dynamic/public';
+import { getRuntimeConfig } from '$lib/runtime/config';
 
 type AnyRecord = Record<string, any>;
 
@@ -31,7 +32,12 @@ function updateLastT(t?: number) {
 }
 
 function wsUrl(): string {
-  const configured = (publicEnv?.PUBLIC_WS_URL as string | undefined) || undefined;
+  const runtime = getRuntimeConfig();
+  const runtimeConfigured = runtime?.PUBLIC_WS_URL?.trim();
+  const configured =
+    runtimeConfigured && runtimeConfigured.length > 0
+      ? runtimeConfigured
+      : ((publicEnv?.PUBLIC_WS_URL as string | undefined) || undefined)?.trim();
   if (configured) {
     if (configured.startsWith('ws://') || configured.startsWith('wss://')) return configured;
     if (!browser) return `ws://${configured}`;

--- a/src/lib/runtime/config.ts
+++ b/src/lib/runtime/config.ts
@@ -1,0 +1,39 @@
+export type RuntimeConfig = {
+	PUBLIC_BASE_PATH?: string;
+	PUBLIC_API_BASE_URL?: string;
+	PUBLIC_WS_URL?: string;
+};
+
+declare global {
+	var __RUNTIME_CONFIG__: RuntimeConfig | undefined;
+	interface Window {
+		__RUNTIME_CONFIG__?: RuntimeConfig;
+	}
+}
+
+let cachedConfig: RuntimeConfig | null | undefined;
+
+export function getRuntimeConfig(): RuntimeConfig | null {
+	if (cachedConfig !== undefined) {
+		return cachedConfig;
+	}
+	if (typeof globalThis !== 'undefined') {
+		const globalWithConfig = globalThis as typeof globalThis & {
+			__RUNTIME_CONFIG__?: RuntimeConfig;
+		};
+		const maybeConfig = globalWithConfig.__RUNTIME_CONFIG__;
+		if (maybeConfig && typeof maybeConfig === 'object') {
+			cachedConfig = maybeConfig as RuntimeConfig;
+			return cachedConfig;
+		}
+	}
+	cachedConfig = null;
+	return cachedConfig;
+}
+
+export function getRuntimeConfigValue<K extends keyof RuntimeConfig>(
+	key: K
+): RuntimeConfig[K] | undefined {
+	const config = getRuntimeConfig();
+	return config ? config[key] : undefined;
+}

--- a/static/runtime-env.js
+++ b/static/runtime-env.js
@@ -1,0 +1,5 @@
+window.__RUNTIME_CONFIG__ = window.__RUNTIME_CONFIG__ || {
+        PUBLIC_BASE_PATH: '',
+        PUBLIC_API_BASE_URL: '',
+        PUBLIC_WS_URL: ''
+};


### PR DESCRIPTION
## Summary
- add an nginx entrypoint that emits `/usr/share/nginx/html/runtime-env.js` from container environment variables at startup
- load the generated runtime config in the Svelte app and use it for REST and WebSocket client URLs, with a dev fallback script
- document the runtime configuration flow for the Docker image

## Testing
- npm run lint *(fails: repository has existing formatting/lint issues in untouched files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccc0b55bc4832295b2706922666a11