### PR TITLE
fix: ensure auth routes load assets from root

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -24,12 +24,12 @@ const config = {
 			strict: false,
 			assets: assetOutDir
 		}),
-		paths: {
-			base: dev ? '' : basePath,
-			assets: '',
-			relative: basePath ? false : true
-		}
-	}
+                paths: {
+                        base: dev ? '' : basePath,
+                        assets: '',
+                        relative: false
+                }
+        }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- ensure SvelteKit always generates absolute asset URLs so dynamic confirmation and recovery routes no longer request `_app` files relative to the token path

## Testing
- npm run lint *(fails: existing repository-wide Prettier formatting warnings)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd285bae08322adc458f247ec116d