### PR TITLE
fix: scope prerender to marketing page

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,1 @@
-export const prerender = true;
+export const prerender = false;

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,0 +1,1 @@
+export const prerender = true;


### PR DESCRIPTION
## Summary
- remove the root layout prerender flag so non-static routes render through the auth UI
- keep the marketing homepage prerendered by adding a dedicated +page.ts export

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173
- curl -s http://127.0.0.1:4173/confirmation/123/abc | sed -n '1,120p'
- curl -s http://127.0.0.1:4173/recovery/123/abc | sed -n '1,120p'

------
https://chatgpt.com/codex/tasks/task_e_68ccdb69fefc83229c1492f3f1692f01