### PR TITLE
Fix invite preview API base resolution

### DIFF
--- a/src/lib/client/api.ts
+++ b/src/lib/client/api.ts
@@ -10,73 +10,57 @@ import {
 	SearchApiFactory
 } from '$lib/api';
 import axios, { type AxiosInstance } from 'axios';
-import { env as publicEnv } from '$env/dynamic/public';
-import { getRuntimeConfig } from '$lib/runtime/config';
+import { computeApiBase } from '$lib/runtime/api';
 
 // Stringify payloads so bigint values emit as int64 numbers instead of quoted strings
 function stringifyBigInt(data: unknown): string {
-	return JSON.stringify(
-		data,
-		(_, v) => (typeof v === 'bigint' ? v.toString() + '#bigint' : v)
-        ).replace(/"(-?\d+)#bigint"/g, '$1');
+	return JSON.stringify(data, (_, v) =>
+		typeof v === 'bigint' ? v.toString() + '#bigint' : v
+	).replace(/"(-?\d+)#bigint"/g, '$1');
 }
 
 // Centralized API client factory using the generated OpenAPI client.
 // Injects the bearer token dynamically via configuration.accessToken.
 
 export type ApiGroup = {
-        auth: AuthApi;
-        guild: GuildApi;
+	auth: AuthApi;
+	guild: GuildApi;
 	guildInvites: GuildInvitesApi;
-        message: MessageApi;
-        search: ReturnType<typeof SearchApiFactory>;
-        user: UserApi;
+	message: MessageApi;
+	search: ReturnType<typeof SearchApiFactory>;
+	user: UserApi;
 	webhook: WebhookApi;
 };
-
-function computeApiBase(): string {
-        const runtime = getRuntimeConfig();
-        const runtimeConfigured = runtime?.PUBLIC_API_BASE_URL?.trim();
-        if (runtimeConfigured && runtimeConfigured.length > 0) {
-		return runtimeConfigured.replace(/\/+$/, '');
-        }
-        const configured = ((publicEnv?.PUBLIC_API_BASE_URL as string | undefined) || undefined)?.trim();
-        if (configured && configured.length > 0) {
-		return configured.replace(/\/+$/, '');
-        }
-        // Fallback: explicit localhost for both browser and SSR to avoid relying on a dev proxy
-	return 'http://localhost/api/v1';
-}
 
 export function createApi(
 	getToken: () => string | null,
 	refresh?: () => Promise<boolean>
 ): ApiGroup {
 	const basePath = computeApiBase();
-        const config = new Configuration({
+	const config = new Configuration({
 		basePath
-        });
+	});
 
-        // The generated OpenAPI client will JSON.stringify payloads before our axios
-        // transform runs, which breaks when the payload contains bigint values.
-        // Override the JSON MIME detection so the generator skips its own
-        // serialization step and lets our custom transformer handle it.
-        config.isJsonMime = () => false;
+	// The generated OpenAPI client will JSON.stringify payloads before our axios
+	// transform runs, which breaks when the payload contains bigint values.
+	// Override the JSON MIME detection so the generator skips its own
+	// serialization step and lets our custom transformer handle it.
+	config.isJsonMime = () => false;
 
-        // Create a dedicated axios instance with an auth interceptor
-        const ax: AxiosInstance = axios.create();
-        ax.defaults.transformRequest = [
+	// Create a dedicated axios instance with an auth interceptor
+	const ax: AxiosInstance = axios.create();
+	ax.defaults.transformRequest = [
 		(data, headers) => {
-		        if (data != null && typeof data === 'object') {
-		                (headers as any)['Content-Type'] = 'application/json';
-		                return stringifyBigInt(data);
-		        }
-		        return data;
+			if (data != null && typeof data === 'object') {
+				(headers as any)['Content-Type'] = 'application/json';
+				return stringifyBigInt(data);
+			}
+			return data;
 		}
-        ];
+	];
 
-        // Preserve large int64 values as strings to avoid precision loss
-        function parseJSONPreserveLargeInts(data: string) {
+	// Preserve large int64 values as strings to avoid precision loss
+	function parseJSONPreserveLargeInts(data: string) {
 		let out = '';
 		let i = 0;
 		let inStr = false;

--- a/src/lib/runtime/api.ts
+++ b/src/lib/runtime/api.ts
@@ -1,0 +1,23 @@
+import { env as publicEnv } from '$env/dynamic/public';
+import { getRuntimeConfig } from './config';
+
+function sanitizeBase(url: string | undefined | null): string | null {
+	if (!url) return null;
+	const trimmed = url.trim();
+	if (!trimmed) return null;
+	return trimmed.replace(/\/+$/, '');
+}
+
+export function computeApiBase(fallback: string = 'http://localhost/api/v1'): string {
+	const runtimeConfigured = sanitizeBase(getRuntimeConfig()?.PUBLIC_API_BASE_URL);
+	if (runtimeConfigured) {
+		return runtimeConfigured;
+	}
+
+	const envConfigured = sanitizeBase(publicEnv?.PUBLIC_API_BASE_URL as string | undefined);
+	if (envConfigured) {
+		return envConfigured;
+	}
+
+	return sanitizeBase(fallback) ?? fallback;
+}

--- a/src/routes/app/i/[invite_code]/+page.ts
+++ b/src/routes/app/i/[invite_code]/+page.ts
@@ -1,48 +1,53 @@
 import type { PageLoad } from './$types';
 import type { DtoInvitePreview } from '$lib/api';
-import { env as publicEnv } from '$env/dynamic/public';
+import { computeApiBase } from '$lib/runtime/api';
 
 export const prerender = false;
 
-function sanitizeBase(url: string | undefined | null): string | null {
-        if (!url) return null;
-        const trimmed = url.trim();
-        if (!trimmed) return null;
-        return trimmed.replace(/\/+$/, '');
-}
-
 export const load: PageLoad = async ({ params, fetch }) => {
-        const inviteCode = params.invite_code;
-        let invite: DtoInvitePreview | null = null;
-        let inviteState: 'ok' | 'not-found' | 'error' = 'error';
+	const inviteCode = params.invite_code;
+	let invite: DtoInvitePreview | null = null;
+	let inviteState: 'ok' | 'not-found' | 'error' = 'error';
 
-        const baseFromEnv = sanitizeBase(publicEnv?.PUBLIC_API_BASE_URL as string | undefined);
-        const base = baseFromEnv ?? '/api/v1';
-        const endpoint = `${base}/guild/invites/receive/${encodeURIComponent(inviteCode)}`;
+	const base = computeApiBase('/api/v1');
+	const endpoint = `${base}/guild/invites/receive/${encodeURIComponent(inviteCode)}`;
 
-        try {
-                const response = await fetch(endpoint, {
-                        headers: {
-                                Accept: 'application/json'
-                        }
-                });
+	try {
+		const response = await fetch(endpoint, {
+			headers: {
+				Accept: 'application/json'
+			}
+		});
 
-                if (response.ok) {
-                        invite = (await response.json()) as DtoInvitePreview;
-                        inviteState = 'ok';
-                } else if (response.status === 404) {
-                        inviteState = 'not-found';
-                } else {
-                        inviteState = 'error';
-                }
-        } catch (error) {
-                console.error('Failed to load invite preview', error);
-                inviteState = 'error';
-        }
+		const contentType = response.headers.get('content-type') ?? '';
+		const isJson = contentType.toLowerCase().includes('application/json');
 
-        return {
-                inviteCode,
-                invite,
-                inviteState
-        };
+		if (response.ok) {
+			if (!isJson) {
+				console.error('Invite preview response did not return JSON payload', contentType);
+				inviteState = 'error';
+			} else {
+				try {
+					invite = (await response.json()) as DtoInvitePreview;
+					inviteState = 'ok';
+				} catch (parseError) {
+					console.error('Failed to parse invite preview response', parseError);
+					inviteState = 'error';
+				}
+			}
+		} else if (response.status === 404 && isJson) {
+			inviteState = 'not-found';
+		} else {
+			inviteState = 'error';
+		}
+	} catch (error) {
+		console.error('Failed to load invite preview', error);
+		inviteState = 'error';
+	}
+
+	return {
+		inviteCode,
+		invite,
+		inviteState
+	};
 };


### PR DESCRIPTION
## Summary
- extract a reusable runtime-aware API base resolver under `src/lib/runtime`
- update the OpenAPI client and invite preview loader to use the shared resolver
- guard the invite preview fetch against non-JSON responses so HTML fallbacks surface as errors

## Testing
- `npm run lint` *(fails: repository has existing Prettier formatting differences)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce27e8bd448322b2f39cc77e0d431e