### PR TITLE
fix: guard invite preview load on server

### DIFF
--- a/src/routes/app/i/[invite_code]/+page.ts
+++ b/src/routes/app/i/[invite_code]/+page.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment';
 import type { PageLoad } from './$types';
 import type { DtoInvitePreview } from '$lib/api';
 import { computeApiBase } from '$lib/runtime/api';
@@ -6,6 +7,16 @@ export const prerender = false;
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	const inviteCode = params.invite_code;
+	const defaultResult = {
+		inviteCode,
+		invite: null as DtoInvitePreview | null,
+		inviteState: 'error' as 'ok' | 'not-found' | 'error'
+	};
+
+	if (!browser) {
+		return defaultResult;
+	}
+
 	let invite: DtoInvitePreview | null = null;
 	let inviteState: 'ok' | 'not-found' | 'error' = 'error';
 


### PR DESCRIPTION
## Summary
- guard the invite preview loader so SSR returns a default payload until the browser runtime config is ready
- run the invite preview fetch only in the browser so `computeApiBase` can read the runtime config

## Testing
- npm run lint *(fails: existing prettier formatting warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2e4110048322b4191e378c94e119