### PR TITLE
fix: disable ssr for invite preview route

### DIFF
--- a/src/routes/app/i/[invite_code]/+page.ts
+++ b/src/routes/app/i/[invite_code]/+page.ts
@@ -1,21 +1,12 @@
-import { browser } from '$app/environment';
 import type { PageLoad } from './$types';
 import type { DtoInvitePreview } from '$lib/api';
 import { computeApiBase } from '$lib/runtime/api';
 
 export const prerender = false;
+export const ssr = false;
 
 export const load: PageLoad = async ({ params, fetch }) => {
 	const inviteCode = params.invite_code;
-	const defaultResult = {
-		inviteCode,
-		invite: null as DtoInvitePreview | null,
-		inviteState: 'error' as 'ok' | 'not-found' | 'error'
-	};
-
-	if (!browser) {
-		return defaultResult;
-	}
 
 	let invite: DtoInvitePreview | null = null;
 	let inviteState: 'ok' | 'not-found' | 'error' = 'error';


### PR DESCRIPTION
## Summary
- disable SSR for the invite preview route so its load function executes entirely in the browser
- rely on the existing browser-only fetch logic to populate invite data after hydration

## Testing
- npm run lint *(fails: repository contains existing Prettier formatting violations)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce3151d3088322b362ba7ed79abbc5