### PR TITLE
feat: restyle invite page and add join workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,196 @@
 				"vitest": "^2.1.4"
 			}
 		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.4.tgz",
+			"integrity": "sha512-cKjSKvWGmAziQWbCouOsFwb14mp1betm8Y7Fn+yglDMUUu3r9DCbJ9iJbeFDenLMqFbIMC0pQP8K+B8LAxX3OQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@csstools/css-calc": "^2.1.4",
+				"@csstools/css-color-parser": "^3.0.10",
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4",
+				"lru-cache": "^11.1.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "6.5.5",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.5.tgz",
+			"integrity": "sha512-kI2MX9pmImjxWT8nxDZY+MuN6r1jJGe7WxizEbsAEPB/zxfW5wYLIiPG1v3UKgEOOP8EsDkp0ZL99oRFAdPM8g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.1.0",
+				"is-potential-custom-element-name": "^1.0.1"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+			"integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+			"integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@csstools/color-helpers": "^5.1.0",
+				"@csstools/css-calc": "^2.1.4"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^3.0.5",
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^3.0.4"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.0.14",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+			"integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.9",
 			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
@@ -2004,6 +2194,18 @@
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2104,6 +2306,18 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.12",
@@ -2350,6 +2564,22 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+			"integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"mdn-data": "2.12.2",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2361,6 +2591,39 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/cssstyle": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.0.tgz",
+			"integrity": "sha512-RveJPnk3m7aarYQ2bJ6iw+Urh55S6FzUiqtBq+TihnTDP4cI8y/TYDqGOyqgnG1J1a6BxJXZsV9JFSTulm9Z7g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/css-color": "^4.0.3",
+				"@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+				"css-tree": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+			"integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^15.0.0"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/debug": {
@@ -2380,6 +2643,15 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/dedent": {
 			"version": "1.5.1",
@@ -2475,6 +2747,21 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/es-define-property": {
@@ -3200,6 +3487,53 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"whatwg-encoding": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/human-id": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/human-id/-/human-id-4.1.1.tgz",
@@ -3208,6 +3542,21 @@
 			"license": "MIT",
 			"bin": {
 				"human-id": "dist/cli.js"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -3280,6 +3629,15 @@
 				"node": ">=0.12.0"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3325,6 +3683,48 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "27.0.0",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+			"integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@asamuzakjp/dom-selector": "^6.5.4",
+				"cssstyle": "^5.3.0",
+				"data-urls": "^6.0.0",
+				"decimal.js": "^10.5.0",
+				"html-encoding-sniffer": "^4.0.0",
+				"http-proxy-agent": "^7.0.2",
+				"https-proxy-agent": "^7.0.6",
+				"is-potential-custom-element-name": "^1.0.1",
+				"parse5": "^7.3.0",
+				"rrweb-cssom": "^0.8.0",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.0",
+				"whatwg-encoding": "^3.1.1",
+				"whatwg-mimetype": "^4.0.0",
+				"whatwg-url": "^15.0.0",
+				"ws": "^8.18.2",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"canvas": "^3.0.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/json-buffer": {
@@ -3712,6 +4112,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lru-cache": {
+			"version": "11.2.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
+			"integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.18",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.18.tgz",
@@ -3730,6 +4142,15 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.12.2",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+			"integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+			"dev": true,
+			"license": "CC0-1.0",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -3965,6 +4386,21 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"entities": "^6.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/path-exists": {
@@ -4346,6 +4782,18 @@
 				"node": ">=0.10"
 			}
 		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -4408,6 +4856,15 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/rrweb-cssom": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -4443,6 +4900,30 @@
 			},
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/semver": {
@@ -4665,6 +5146,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/tailwindcss": {
 			"version": "4.1.13",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.13.tgz",
@@ -4765,6 +5255,30 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.14.tgz",
+			"integrity": "sha512-lMNHE4aSI3LlkMUMicTmAG3tkkitjOQGDTFboPJwAg2kJXKP1ryWEyqujktg5qhrFZOkk5YFzgkxg3jErE+i5w==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tldts-core": "^7.0.14"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.0.14",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.14.tgz",
+			"integrity": "sha512-viZGNK6+NdluOJWwTO9olaugx0bkKhscIdriQQ+lNNhwitIKvb+SvhbYgnCz6j9p7dX3cJntt4agQAKMXLjJ5g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4786,6 +5300,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+			"integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -6104,12 +6648,82 @@
 				}
 			}
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+			"integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=20"
+			}
+		},
 		"node_modules/webpack-virtual-modules": {
 			"version": "0.6.2",
 			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
 			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+			"integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.0"
+			},
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
@@ -6153,6 +6767,51 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/ws": {
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/yallist": {
 			"version": "5.0.0",

--- a/src/routes/app/i/[invite_code]/+page.svelte
+++ b/src/routes/app/i/[invite_code]/+page.svelte
@@ -1,111 +1,29 @@
 <script lang="ts">
 	import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
+	import { goto } from '$app/navigation';
 	import type { PageData } from './$types';
-	import { browser } from '$app/environment';
-	import { onDestroy } from 'svelte';
 	import type { DtoInvitePreview } from '$lib/api';
+	import { auth } from '$lib/stores/auth';
+	import {
+		buildGuildIconUrl,
+		getGuildInitials,
+		getGuildName,
+		getInviteUnavailableMessage,
+		getMemberCountLabel,
+		joinGuild as joinGuildAction,
+		type InviteState
+	} from './invite-utils';
 
 	let { data } = $props<{ data: PageData }>();
-
-	type InviteState = 'ok' | 'not-found' | 'error';
 
 	let invite = $state<DtoInvitePreview | null>(data.invite ?? null);
 	let inviteCodeValue = $state<string>(data.inviteCode ?? '');
 	let inviteState = $state<InviteState>((data.inviteState ?? 'error') as InviteState);
 
-	const compactNumber = new Intl.NumberFormat(undefined, {
-		notation: 'compact',
-		maximumFractionDigits: 1
-	});
-	const standardNumber = new Intl.NumberFormat(undefined, {
-		maximumFractionDigits: 0
-	});
-	const dateTime = new Intl.DateTimeFormat(undefined, {
-		dateStyle: 'medium',
-		timeStyle: 'short'
-	});
+	const isAuthenticated = auth.isAuthenticated;
 
-	function formatMemberCount(count: number | null): string {
-		if (count == null) return 'Member count unavailable';
-		if (count === 0) return 'No members yet';
-		if (count === 1) return '1 member';
-		if (count < 1000) return `${standardNumber.format(count)} members`;
-		return `${compactNumber.format(count)} members`;
-	}
-
-	function createMemberDescription(count: number | null): string {
-		if (count == null) return 'Sign in or create an account to continue.';
-		if (count === 0) return 'Be the first to start the conversation.';
-		if (count === 1) return 'One person is already inside — come say hi!';
-		if (count < 10) return `${standardNumber.format(count)} members are ready to welcome you.`;
-		if (count < 1000)
-			return `Join ${standardNumber.format(count)} members collaborating in this space.`;
-		return `Join ${compactNumber.format(count)} members collaborating in this space.`;
-	}
-
-	function formatDate(value: string | null | undefined): string | null {
-		if (!value) return null;
-		const parsed = new Date(value);
-		if (Number.isNaN(parsed.getTime())) return null;
-		return dateTime.format(parsed);
-	}
-
-	function getDisplayName(current: DtoInvitePreview | null): string {
-		return current?.guild?.name?.trim() || 'GoChat community';
-	}
-
-	function getMemberCount(current: DtoInvitePreview | null): number | null {
-		return current?.members_count ?? null;
-	}
-
-	function getMemberCountLabel(current: DtoInvitePreview | null): string {
-		return formatMemberCount(getMemberCount(current));
-	}
-
-	function getMemberDescription(current: DtoInvitePreview | null): string {
-		return createMemberDescription(getMemberCount(current));
-	}
-
-	function getCreatedLabel(current: DtoInvitePreview | null): string {
-		return formatDate(current?.created_at) ?? 'Created recently';
-	}
-
-	function isInviteExpired(current: DtoInvitePreview | null): boolean {
-		if (!current?.expires_at) return false;
-		const parsed = new Date(current.expires_at);
-		return !Number.isNaN(parsed.getTime()) && parsed.getTime() < Date.now();
-	}
-
-	function getInviteStatusLabel(state: InviteState, current: DtoInvitePreview | null): string {
-		if (state === 'not-found') return 'Unavailable';
-		if (state === 'error') return 'Status unknown';
-		return isInviteExpired(current) ? 'Expired' : 'Active';
-	}
-
-	function getInviteStatusDescriptor(state: InviteState, current: DtoInvitePreview | null): string {
-		if (state === 'not-found') return 'This invite could not be found or has been revoked.';
-		if (state === 'error') return 'Unable to verify the invite status right now.';
-		if (!current?.expires_at) return 'No expiration date';
-		const formatted = formatDate(current.expires_at);
-		if (!formatted) return 'Expiration unknown';
-		return isInviteExpired(current) ? `Expired on ${formatted}` : `Expires on ${formatted}`;
-	}
-
-	function getStatusTone(
-		state: InviteState,
-		current: DtoInvitePreview | null
-	): 'success' | 'danger' | 'warning' {
-		if (state === 'ok') {
-			return isInviteExpired(current) ? 'danger' : 'success';
-		}
-		return state === 'not-found' ? 'danger' : 'warning';
-	}
-
-	function getInviteUnavailableMessage(state: InviteState): string | null {
-		if (state === 'ok') return null;
-		if (state === 'not-found') return 'This invite is no longer available or may have expired.';
-		return 'We were unable to load the invite details. Please try again or contact the guild owner.';
-	}
+	let joining = $state(false);
+	let joinError = $state<string | null>(null);
 
 	function getHeadTitle(current: DtoInvitePreview | null): string {
 		return current?.guild?.name
@@ -113,42 +31,32 @@
 			: 'Join this GoChat community';
 	}
 
-	let copyStatus = $state<'idle' | 'copied' | 'error'>('idle');
-	let copyTimer: ReturnType<typeof setTimeout> | null = null;
+	const guildIconUrl = $derived.by(() => buildGuildIconUrl(invite));
+	const guildInitials = $derived.by(() => getGuildInitials(invite));
+	const guildName = $derived.by(() => getGuildName(invite));
+	const memberCountLabel = $derived.by(() => getMemberCountLabel(invite));
+	const inviteMessage = $derived.by(() => getInviteUnavailableMessage(inviteState));
 
-	async function copyCode() {
-		if (!inviteCodeValue || !browser) return;
-		try {
-			await navigator.clipboard.writeText(inviteCodeValue);
-			copyStatus = 'copied';
-		} catch (error) {
-			console.error('Failed to copy invite code', error);
-			copyStatus = 'error';
+	async function handleJoin() {
+		if (!inviteCodeValue || inviteState !== 'ok' || joining) return;
+		joining = true;
+		joinError = null;
+		const result = await joinGuildAction(inviteCodeValue, '/app', {
+			acceptInvite: (params) => auth.api.guildInvites.guildInvitesAcceptInviteCodePost(params),
+			loadGuilds: () => auth.loadGuilds(),
+			goto
+		});
+		if (!result.success) {
+			joinError = result.message;
 		}
-
-		if (copyTimer) clearTimeout(copyTimer);
-		copyTimer = setTimeout(() => {
-			copyStatus = 'idle';
-		}, 2400);
+		joining = false;
 	}
-
-	onDestroy(() => {
-		if (copyTimer) clearTimeout(copyTimer);
-	});
 
 	$effect(() => {
 		invite = (data.invite ?? null) as DtoInvitePreview | null;
 		inviteCodeValue = data.inviteCode ?? '';
 		inviteState = (data.inviteState ?? 'error') as InviteState;
-	});
-
-	$effect(() => {
-		inviteCodeValue;
-		copyStatus = 'idle';
-		if (copyTimer) {
-			clearTimeout(copyTimer);
-			copyTimer = null;
-		}
+		joinError = null;
 	});
 </script>
 
@@ -156,324 +64,56 @@
 	<title>{getHeadTitle(invite)}</title>
 </svelte:head>
 
-<div class="relative isolate min-h-screen overflow-hidden bg-[var(--bg)] text-[var(--text)]">
-	<div class="pointer-events-none absolute inset-0 -z-10">
-		<div
-			class="absolute -top-40 left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-indigo-500/25 blur-3xl"
-		></div>
-		<div
-			class="absolute right-[-12rem] bottom-[-18rem] h-[36rem] w-[36rem] rounded-full bg-fuchsia-500/20 blur-3xl"
-		></div>
-		<div
-			class="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(148,163,184,0.08),transparent_65%)]"
-		></div>
-	</div>
-
-	<header class="relative border-b border-[var(--stroke)] bg-[var(--panel)]/60 backdrop-blur">
-		<div
-			class="mx-auto flex w-full max-w-5xl flex-wrap items-center justify-between gap-4 px-6 py-5"
-		>
-			<a class="flex items-center gap-3 text-[var(--text)] no-underline" href="/">
-				<span
-					class="grid h-11 w-11 place-items-center rounded-2xl bg-gradient-to-tr from-indigo-500 via-violet-500 to-fuchsia-500 text-white shadow-lg"
-					aria-hidden="true"
-				>
-					<svg
-						viewBox="0 0 36 36"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						class="h-6 w-6"
-					>
-						<path
-							d="M9 15.5c0-4.418 3.134-8 7-8h4c3.866 0 7 3.582 7 8 0 2.53-1.142 4.79-2.893 6.203-.42.343-.638.875-.582 1.42l.238 2.29c.132 1.264-1.23 2.105-2.265 1.373l-2.908-2.063a1.5 1.5 0 0 0-1.708 0l-2.907 2.063c-1.036.732-2.397-.109-2.265-1.373l.238-2.29c.056-.545-.162-1.077-.582-1.42C10.142 20.29 9 18.03 9 15.5Z"
-						/>
-					</svg>
-				</span>
-				<span
-					class="flex flex-col text-[10px] font-semibold tracking-[0.26em] text-[var(--muted)] uppercase"
-				>
-					<span class="text-base font-semibold tracking-tight text-[var(--text)]">GoChat</span>
-					<span class="font-medium text-[var(--muted)]">Community invite</span>
-				</span>
-			</a>
-			<a
-				class="inline-flex items-center gap-2 rounded-full border border-[var(--stroke)] bg-[var(--panel)] px-4 py-2 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--brand)] hover:text-[var(--brand)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none"
-				href="/app"
-			>
-				<span>Open app</span>
-				<svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-					<path
-						d="M11.172 5H6a1 1 0 1 1 0-2h8a1 1 0 0 1 1 1v8a1 1 0 1 1-2 0V7.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L11.172 5Z"
-					/>
-				</svg>
-			</a>
-		</div>
-	</header>
-
-	<main
-		class="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,22rem)] lg:items-start lg:gap-12 lg:py-16"
-	>
-		<section
-			class="panel relative flex flex-col gap-6 overflow-hidden border border-[var(--stroke)]/80 bg-[var(--panel-strong)]/80 p-6 shadow-[var(--shadow-1)] sm:p-8"
-			aria-labelledby="guild-title"
-		>
+{#if !$isAuthenticated}
+	<AuthGate redirectTo={`/app/i/${inviteCodeValue}`} />
+{:else}
+	<div class="min-h-screen bg-[var(--bg)] py-10 text-[var(--text)]">
+		<div class="mx-auto flex min-h-[60vh] w-full max-w-3xl items-center justify-center px-4">
 			<div
-				class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,rgba(99,102,241,0.18),transparent_65%)]"
-			></div>
-			<span
-				class="inline-flex items-center rounded-full border border-[var(--stroke)]/60 bg-[var(--panel)]/60 px-3 py-1 text-xs font-semibold tracking-[0.26em] text-[var(--muted)] uppercase"
+				class="panel w-full max-w-xl border border-[var(--stroke)] bg-[var(--panel)] p-8 shadow-[var(--shadow-2)]"
 			>
-				Exclusive invite
-			</span>
-			<div class="space-y-3">
-				<h1
-					id="guild-title"
-					class="text-3xl leading-tight font-semibold text-[var(--text)] sm:text-4xl"
-				>
-					{getDisplayName(invite)}
-				</h1>
-				<p class="max-w-xl text-sm leading-relaxed text-[var(--text-2)] sm:text-base">
-					{getMemberDescription(invite)}
-				</p>
-			</div>
-
-			{#if getInviteUnavailableMessage(inviteState)}
-				<div
-					class="flex gap-3 rounded-2xl border border-[var(--stroke)] bg-[var(--panel)]/80 p-4 text-sm text-[var(--muted)]"
-					role="status"
-				>
-					<span
-						class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--danger)]/10 text-[var(--danger)]"
-						aria-hidden="true"
+				<div class="flex flex-col items-center gap-4 text-center">
+					<div
+						class="grid h-20 w-20 place-items-center overflow-hidden rounded-2xl border border-[var(--stroke)] bg-[var(--panel-strong)] text-2xl font-semibold"
 					>
-						<svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
-							<path
-								fill-rule="evenodd"
-								d="M8.257 3.099c.765-1.36 2.72-1.36 3.485 0l6.518 11.596c.75 1.335-.213 3.005-1.742 3.005H3.48c-1.53 0-2.493-1.67-1.743-3.005L8.257 3.1ZM11 14a1 1 0 1 0-2 0 1 1 0 0 0 2 0Zm-.25-6.75a.75.75 0 0 0-1.5 0v4a.75.75 0 0 0 1.5 0v-4Z"
-								clip-rule="evenodd"
+						{#if guildIconUrl}
+							<img
+								alt={`Guild icon for ${guildName}`}
+								class="h-full w-full object-cover"
+								src={guildIconUrl}
 							/>
-						</svg>
-					</span>
+						{:else}
+							<span>{guildInitials}</span>
+						{/if}
+					</div>
 					<div class="space-y-1">
-						<p class="text-sm font-semibold text-[var(--text)]">Invite unavailable</p>
-						<p>{getInviteUnavailableMessage(inviteState)}</p>
+						<h1 class="text-2xl font-semibold text-[var(--text)] sm:text-3xl">{guildName}</h1>
+						<p class="text-sm text-[var(--muted)]">{memberCountLabel}</p>
 					</div>
 				</div>
-			{/if}
 
-			<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-				<div
-					class="flex items-start gap-3 rounded-xl border border-[var(--stroke)] bg-[var(--panel)]/70 p-4"
-				>
-					<span
-						class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--stroke)]/60 bg-[var(--panel-strong)]/70 text-[var(--brand)]"
-						aria-hidden="true"
+				{#if inviteMessage}
+					<div
+						class="mt-6 rounded-lg border border-[var(--stroke)] bg-[var(--panel-strong)] p-4 text-sm text-[var(--muted)]"
 					>
-						<svg
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.6"
-							class="h-5 w-5"
-						>
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8Zm0 2c-3.314 0-6 2.015-6 4.5V20h12v-1.5c0-2.485-2.686-4.5-6-4.5Z"
-							/>
-						</svg>
-					</span>
-					<div class="space-y-1 text-sm">
-						<p class="text-xs font-medium tracking-wide text-[var(--muted)] uppercase">
-							Community size
-						</p>
-						<p class="font-semibold text-[var(--text)]">{getMemberCountLabel(invite)}</p>
+						{inviteMessage}
 					</div>
-				</div>
-				<div
-					class="flex items-start gap-3 rounded-xl border border-[var(--stroke)] bg-[var(--panel)]/70 p-4"
-				>
-					<span
-						class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--stroke)]/60 bg-[var(--panel-strong)]/70 text-[var(--brand)]"
-						aria-hidden="true"
+				{/if}
+
+				<div class="mt-6 space-y-3">
+					<button
+						class="h-11 w-full rounded-md bg-[var(--brand)] font-semibold text-[var(--bg)] transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+						type="button"
+						disabled={inviteState !== 'ok' || joining}
+						on:click={handleJoin}
 					>
-						<svg
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.6"
-							class="h-5 w-5"
-						>
-							<rect x="4" y="5" width="16" height="15" rx="2" ry="2" />
-							<path stroke-linecap="round" d="M16 3v4M8 3v4M4 10h16" />
-						</svg>
-					</span>
-					<div class="space-y-1 text-sm">
-						<p class="text-xs font-medium tracking-wide text-[var(--muted)] uppercase">Created</p>
-						<p class="font-semibold text-[var(--text)]">{getCreatedLabel(invite)}</p>
-					</div>
-				</div>
-				<div
-					class="flex items-start gap-3 rounded-xl border border-[var(--stroke)] bg-[var(--panel)]/70 p-4"
-				>
-					<span
-						class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--stroke)]/60 bg-[var(--panel-strong)]/70 text-[var(--brand)]"
-						aria-hidden="true"
-					>
-						<svg
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="1.6"
-							class="h-5 w-5"
-						>
-							<circle cx="12" cy="12" r="9" />
-							<path stroke-linecap="round" stroke-linejoin="round" d="M12 7v5l3 3" />
-						</svg>
-					</span>
-					<div class="space-y-1 text-sm">
-						<p class="text-xs font-medium tracking-wide text-[var(--muted)] uppercase">
-							Invite status
-						</p>
-						<div class="flex items-center gap-2 font-semibold text-[var(--text)]">
-							<span>{getInviteStatusLabel(inviteState, invite)}</span>
-							<span
-								class="inline-flex items-center rounded-full border border-[var(--stroke)]/50 px-2 py-0.5 text-[10px] font-semibold tracking-wide uppercase"
-								style={`background: var(--${getStatusTone(inviteState, invite)}); color: var(--bg);`}
-								aria-hidden="true"
-							>
-								{getInviteStatusLabel(inviteState, invite)}
-							</span>
-						</div>
-						<p class="text-xs text-[var(--muted)]">
-							{getInviteStatusDescriptor(inviteState, invite)}
-						</p>
-					</div>
+						{joining ? 'Joining…' : 'Join guild'}
+					</button>
+					{#if joinError}
+						<p class="text-sm text-[var(--danger)]">{joinError}</p>
+					{/if}
 				</div>
 			</div>
-
-			<div
-				class="flex flex-col gap-4 rounded-2xl border border-[var(--stroke)] bg-[var(--panel-strong)]/80 p-4 sm:flex-row sm:items-center sm:justify-between"
-			>
-				<div>
-					<span class="text-xs font-medium tracking-wide text-[var(--muted)] uppercase"
-						>Invite code</span
-					>
-					<code
-						class="mt-1 block font-mono text-lg tracking-[0.25em] text-[var(--text)] sm:text-xl"
-						aria-label={`Invite code ${inviteCodeValue || 'unavailable'}`}
-					>
-						{inviteCodeValue || 'Unavailable'}
-					</code>
-				</div>
-				<button
-					class="inline-flex items-center gap-2 self-start rounded-full bg-[var(--brand)] px-4 py-2 text-sm font-semibold text-[var(--bg)] shadow-sm transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-					type="button"
-					onclick={copyCode}
-					disabled={!inviteCodeValue}
-				>
-					<svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-						<path
-							d="M4 4a2 2 0 0 1 2-2h5.5a2 2 0 0 1 2 2v2H15a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2v-2H6a2 2 0 0 1-2-2V4Zm7.5 2V4H6v7h1V8a2 2 0 0 1 2-2h2.5Z"
-						/>
-					</svg>
-					<span
-						>{copyStatus === 'copied'
-							? 'Copied'
-							: copyStatus === 'error'
-								? 'Copy failed'
-								: 'Copy code'}</span
-					>
-				</button>
-			</div>
-			<p class="min-h-[1.25rem] text-xs text-[var(--muted)]" aria-live="polite">
-				{#if copyStatus === 'copied'}Invite code copied to clipboard.{:else if copyStatus === 'error'}Unable
-					to copy the invite code.{/if}
-			</p>
-
-			<div class="flex flex-wrap items-center gap-3">
-				<a
-					class="inline-flex items-center gap-2 rounded-full bg-[var(--brand)] px-4 py-2 text-sm font-semibold text-[var(--bg)] shadow-sm transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none"
-					href="/app"
-				>
-					<span>Launch GoChat</span>
-					<svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-						<path
-							d="M12.293 4.293a1 1 0 0 1 1.414 0l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 1 1-1.414-1.414L14.586 10H4a1 1 0 1 1 0-2h10.586l-2.293-2.293a1 1 0 0 1 0-1.414Z"
-						/>
-					</svg>
-				</a>
-				<a
-					class="inline-flex items-center gap-2 rounded-full border border-[var(--stroke)] bg-[var(--panel)] px-4 py-2 text-sm font-semibold text-[var(--text)] transition hover:border-[var(--brand)] hover:text-[var(--brand)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none"
-					href="/"
-				>
-					<span>Discover GoChat</span>
-				</a>
-			</div>
-			<p class="text-xs text-[var(--muted)]">Sign in or create an account to accept this invite.</p>
-		</section>
-
-		<section class="space-y-4" aria-label="Sign in or create an account">
-			<h2 class="text-sm font-semibold tracking-wide text-[var(--muted)] uppercase">
-				Access your account
-			</h2>
-			<div class="panel border border-[var(--stroke)] bg-[var(--panel)]/80 p-4 sm:p-6">
-				<div class="invite-auth">
-					<AuthGate>
-						<div
-							class="flex flex-col gap-4 rounded-2xl border border-[var(--stroke)] bg-[var(--panel-strong)]/80 p-6 text-left shadow-sm"
-							role="status"
-						>
-							<span
-								class="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--success)]/15 text-[var(--success)]"
-								aria-hidden="true"
-							>
-								<svg
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									stroke-width="2"
-									class="h-6 w-6"
-								>
-									<path stroke-linecap="round" stroke-linejoin="round" d="M5 12.5 10.5 18 19 6" />
-								</svg>
-							</span>
-							<h2 class="text-lg font-semibold text-[var(--text)]">You're already signed in</h2>
-							<p class="text-sm leading-relaxed text-[var(--text-2)]">
-								Launch the app to finish joining {invite?.guild?.name ?? 'this guild'}.
-							</p>
-							<a
-								class="inline-flex items-center gap-2 self-start rounded-full bg-[var(--brand)] px-4 py-2 text-sm font-semibold text-[var(--bg)] shadow-sm transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none"
-								href="/app"
-							>
-								<span>Continue to GoChat</span>
-								<svg viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4" aria-hidden="true">
-									<path
-										d="M12.293 4.293a1 1 0 0 1 1.414 0l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 1 1-1.414-1.414L14.586 10H4a1 1 0 1 1 0-2h10.586l-2.293-2.293a1 1 0 0 1 0-1.414Z"
-									/>
-								</svg>
-							</a>
-						</div>
-					</AuthGate>
-				</div>
-			</div>
-		</section>
-	</main>
-</div>
-
-<style>
-	:global(.invite-auth > div) {
-		display: flex !important;
-		width: 100% !important;
-		height: auto !important;
-		min-height: 0 !important;
-		padding: 0 !important;
-		justify-content: center;
-	}
-
-	:global(.invite-auth > div .panel) {
-		width: 100%;
-		max-width: 26rem;
-	}
-</style>
+		</div>
+	</div>
+{/if}

--- a/src/routes/app/i/[invite_code]/invite-utils.spec.ts
+++ b/src/routes/app/i/[invite_code]/invite-utils.spec.ts
@@ -1,0 +1,84 @@
+/// <reference types="vitest" />
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	buildGuildIconUrl,
+	getGuildInitials,
+	getGuildName,
+	getInviteUnavailableMessage,
+	getMemberCountLabel,
+	joinGuild,
+	type JoinGuildDeps
+} from './invite-utils';
+
+vi.mock('$lib/runtime/api', () => ({
+	computeApiBase: () => 'https://api.test'
+}));
+
+describe('invite-utils', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('computes guild initials and member counts', () => {
+		const invite = {
+			guild: { name: 'Design Collective', icon: 42 },
+			members_count: 1250
+		} as any;
+
+		expect(getGuildName(invite)).toBe('Design Collective');
+		expect(getGuildInitials(invite)).toBe('DC');
+		expect(getMemberCountLabel(invite)).toBe('1,250 members');
+	});
+
+	it('falls back when guild metadata is missing', () => {
+		const invite = { guild: {}, members_count: null } as any;
+		expect(getGuildName(invite)).toBe('GoChat community');
+		expect(getGuildInitials(invite)).toBe('GC');
+		expect(getMemberCountLabel(invite)).toBe('Member count unavailable');
+	});
+
+	it('builds the guild icon URL when an icon is present', () => {
+		const inviteWithIcon = { guild: { icon: 77 } } as any;
+		const inviteWithoutIcon = { guild: {} } as any;
+
+		expect(buildGuildIconUrl(inviteWithIcon)).toBe('https://api.test/attachments/77');
+		expect(buildGuildIconUrl(inviteWithoutIcon)).toBeNull();
+	});
+
+	it('provides invite availability messaging', () => {
+		expect(getInviteUnavailableMessage('ok')).toBeNull();
+		expect(getInviteUnavailableMessage('not-found')).toContain('no longer available');
+		expect(getInviteUnavailableMessage('error')).toContain('try again later');
+	});
+
+	it('joins the guild through the provided dependencies', async () => {
+		const deps: JoinGuildDeps = {
+			acceptInvite: vi.fn().mockResolvedValue(undefined),
+			loadGuilds: vi.fn().mockResolvedValue(undefined),
+			goto: vi.fn().mockResolvedValue(undefined)
+		};
+
+		const result = await joinGuild('creative', '/app', deps);
+
+		expect(result).toEqual({ success: true });
+		expect(deps.acceptInvite).toHaveBeenCalledWith({ inviteCode: 'creative' });
+		expect(deps.loadGuilds).toHaveBeenCalled();
+		expect(deps.goto).toHaveBeenCalledWith('/app');
+	});
+
+	it('returns the API error message when joining fails', async () => {
+		const deps: JoinGuildDeps = {
+			acceptInvite: vi.fn().mockRejectedValue({
+				response: { data: { message: 'Invite expired' } }
+			}),
+			loadGuilds: vi.fn(),
+			goto: vi.fn()
+		};
+
+		const result = await joinGuild('expired', '/app', deps);
+
+		expect(result).toEqual({ success: false, message: 'Invite expired' });
+		expect(deps.goto).not.toHaveBeenCalled();
+	});
+});

--- a/src/routes/app/i/[invite_code]/invite-utils.ts
+++ b/src/routes/app/i/[invite_code]/invite-utils.ts
@@ -1,0 +1,68 @@
+import type { DtoInvitePreview } from '$lib/api';
+import { computeApiBase } from '$lib/runtime/api';
+
+export type InviteState = 'ok' | 'not-found' | 'error';
+
+const memberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+export function getGuildName(invite: DtoInvitePreview | null): string {
+	return invite?.guild?.name?.trim() || 'GoChat community';
+}
+
+export function getGuildInitials(invite: DtoInvitePreview | null): string {
+	const name = getGuildName(invite);
+	const segments = name.split(/\s+/).filter(Boolean).slice(0, 2);
+	if (segments.length === 0) return '?';
+	return segments.map((segment) => segment[0]?.toUpperCase() ?? '').join('') || '?';
+}
+
+export function getMemberCountLabel(invite: DtoInvitePreview | null): string {
+	const count = invite?.members_count;
+	if (count == null) return 'Member count unavailable';
+	if (count === 1) return '1 member';
+	return `${memberFormatter.format(count)} members`;
+}
+
+export function buildGuildIconUrl(invite: DtoInvitePreview | null): string | null {
+	const iconId = invite?.guild?.icon;
+	if (iconId == null) return null;
+	const base = computeApiBase();
+	const normalized = base.replace(/\/$/, '');
+	return `${normalized}/attachments/${iconId}`;
+}
+
+export function getInviteUnavailableMessage(state: InviteState): string | null {
+	if (state === 'ok') return null;
+	if (state === 'not-found') {
+		return 'This invite is no longer available or may have expired.';
+	}
+	return 'We were unable to load the invite details. Please try again later.';
+}
+
+export type JoinGuildDeps = {
+	acceptInvite: (params: { inviteCode: string }) => Promise<unknown>;
+	loadGuilds: () => Promise<unknown>;
+	goto: (path: string) => Promise<unknown> | unknown;
+};
+
+export async function joinGuild(
+	inviteCode: string,
+	destination: string,
+	deps: JoinGuildDeps
+): Promise<{ success: true } | { success: false; message: string }> {
+	try {
+		await deps.acceptInvite({ inviteCode });
+		await deps.loadGuilds().catch(() => {});
+		await deps.goto(destination);
+		return { success: true };
+	} catch (error) {
+		const err = error as {
+			response?: { data?: { message?: string } };
+			message?: string;
+		};
+		return {
+			success: false,
+			message: err?.response?.data?.message ?? err?.message ?? 'Failed to join guild'
+		};
+	}
+}

--- a/src/routes/app/i/[invite_code]/page.spec.ts
+++ b/src/routes/app/i/[invite_code]/page.spec.ts
@@ -11,137 +11,147 @@ type LoadResult = Awaited<ReturnType<LoadFn>>;
 const guildInvitesReceiveInviteCodeGetMock = vi.fn();
 
 vi.mock('$lib/stores/auth', () => ({
-        auth: {
-                api: {
-                        guildInvites: {
-                                guildInvitesReceiveInviteCodeGet: guildInvitesReceiveInviteCodeGetMock
-                        }
-                }
-        }
+	auth: {
+		api: {
+			guildInvites: {
+				guildInvitesReceiveInviteCodeGet: guildInvitesReceiveInviteCodeGetMock
+			}
+		}
+	}
 }));
 
 async function importPageModule(): Promise<PageModule> {
-        return import('./+page');
+	return import('./+page');
 }
 
 function setupWindowWithImmediateConfig(config: RuntimeConfig): void {
-        const runtimeWindow = {
-                __RUNTIME_CONFIG__: config,
-                requestAnimationFrame: (callback: FrameRequestCallback) => {
-                        callback(0);
-                        return 0;
-                }
-        } as Window & typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig };
+	const runtimeWindow = {
+		__RUNTIME_CONFIG__: config,
+		requestAnimationFrame: (callback: FrameRequestCallback) => {
+			callback(0);
+			return 0;
+		}
+	} as typeof globalThis & {
+		__RUNTIME_CONFIG__?: RuntimeConfig;
+		requestAnimationFrame: (callback: FrameRequestCallback) => number;
+	};
 
-        (globalThis as typeof globalThis & { window: typeof runtimeWindow }).window = runtimeWindow;
-        (globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__ =
-                config;
+	vi.stubGlobal('window', runtimeWindow);
+	(globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__ =
+		config;
 }
 
 function setupWindowWithDeferredConfig(config: RuntimeConfig): void {
-        let frame = 0;
-        const runtimeWindow = {
-                requestAnimationFrame: (callback: FrameRequestCallback) => {
-                        frame += 1;
-                        if (frame === 2) {
-                                runtimeWindow.__RUNTIME_CONFIG__ = config;
-                                (globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__ =
-                                        config;
-                        }
+	let frame = 0;
+	const runtimeWindow = {
+		requestAnimationFrame: (callback: FrameRequestCallback) => {
+			frame += 1;
+			if (frame === 2) {
+				runtimeWindow.__RUNTIME_CONFIG__ = config;
+				(
+					globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }
+				).__RUNTIME_CONFIG__ = config;
+			}
 
-                        callback(frame);
-                        return frame;
-                }
-        } as Window & typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig };
+			callback(frame);
+			return frame;
+		}
+	} as typeof globalThis & {
+		__RUNTIME_CONFIG__?: RuntimeConfig;
+		requestAnimationFrame: (callback: FrameRequestCallback) => number;
+	};
 
-        runtimeWindow.__RUNTIME_CONFIG__ = undefined;
-        (globalThis as typeof globalThis & { window: typeof runtimeWindow }).window = runtimeWindow;
-        (globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__ =
-                undefined;
+	runtimeWindow.__RUNTIME_CONFIG__ = undefined;
+	vi.stubGlobal('window', runtimeWindow);
+	(globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__ =
+		undefined;
 }
 
-async function executeLoad(inviteCode: string): Promise<{ result: LoadResult; fetch: LoadArgs['fetch'] }> {
-        const module = await importPageModule();
-        const fetch = vi.fn() as unknown as LoadArgs['fetch'];
+async function executeLoad(
+	inviteCode: string
+): Promise<{ result: LoadResult; fetch: LoadArgs['fetch'] }> {
+	const module = await importPageModule();
+	const fetch = vi.fn() as unknown as LoadArgs['fetch'];
 
-        const result = await module.load({
-                params: { invite_code: inviteCode },
-                fetch
-        } as LoadArgs);
+	const result = await module.load({
+		params: { invite_code: inviteCode },
+		fetch
+	} as LoadArgs);
 
-        return { result, fetch };
+	return { result, fetch };
 }
 
 describe('invite page load', () => {
-        beforeEach(() => {
-                vi.resetModules();
-                vi.clearAllMocks();
-                guildInvitesReceiveInviteCodeGetMock.mockReset();
-                Reflect.deleteProperty(globalThis as Record<string, unknown>, 'window');
-                Reflect.deleteProperty(globalThis as Record<string, unknown>, '__RUNTIME_CONFIG__');
-        });
-
-	afterEach(() => {
-		Reflect.deleteProperty(globalThis as Record<string, unknown>, 'window');
+	beforeEach(() => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		guildInvitesReceiveInviteCodeGetMock.mockReset();
+		vi.unstubAllGlobals();
 		Reflect.deleteProperty(globalThis as Record<string, unknown>, '__RUNTIME_CONFIG__');
 	});
 
-        it('fetches the invite preview through the authenticated API when runtime config is ready', async () => {
-                const inviteCode = 'join-me';
-                const payload = { code: inviteCode };
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		Reflect.deleteProperty(globalThis as Record<string, unknown>, '__RUNTIME_CONFIG__');
+	});
 
-                setupWindowWithImmediateConfig({ PUBLIC_API_BASE_URL: 'https://api.example.test' });
-                guildInvitesReceiveInviteCodeGetMock.mockResolvedValue({ data: payload });
+	it('fetches the invite preview through the authenticated API when runtime config is ready', async () => {
+		const inviteCode = 'join-me';
+		const payload = { code: inviteCode };
 
-                const { result, fetch } = await executeLoad(inviteCode);
+		setupWindowWithImmediateConfig({ PUBLIC_API_BASE_URL: 'https://api.example.test' });
+		guildInvitesReceiveInviteCodeGetMock.mockResolvedValue({ data: payload });
 
-                expect(fetch).not.toHaveBeenCalled();
-                expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledTimes(1);
-                expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
+		const { result, fetch } = await executeLoad(inviteCode);
 
-                const loadResult = result as Record<string, unknown>;
-                expect(loadResult.invite).toEqual(payload);
-                expect(loadResult.inviteState).toBe('ok');
-        });
+		expect(fetch).not.toHaveBeenCalled();
+		expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledTimes(1);
+		expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
 
-        it('waits for the runtime API base URL before requesting the invite preview', async () => {
-                const inviteCode = 'delayed';
-                const payload = { code: inviteCode };
-                const config = { PUBLIC_API_BASE_URL: 'https://delayed.example.test' } satisfies RuntimeConfig;
+		const loadResult = result as Record<string, unknown>;
+		expect(loadResult.invite).toEqual(payload);
+		expect(loadResult.inviteState).toBe('ok');
+	});
 
-                setupWindowWithDeferredConfig(config);
-                guildInvitesReceiveInviteCodeGetMock.mockImplementation(() => {
-                        expect(
-                                (globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig }).__RUNTIME_CONFIG__
-                        ).toEqual(config);
-                        return Promise.resolve({ data: payload });
-                });
+	it('waits for the runtime API base URL before requesting the invite preview', async () => {
+		const inviteCode = 'delayed';
+		const payload = { code: inviteCode };
+		const config = { PUBLIC_API_BASE_URL: 'https://delayed.example.test' } satisfies RuntimeConfig;
 
-                const { result } = await executeLoad(inviteCode);
+		setupWindowWithDeferredConfig(config);
+		guildInvitesReceiveInviteCodeGetMock.mockImplementation(() => {
+			expect(
+				(globalThis as typeof globalThis & { __RUNTIME_CONFIG__?: RuntimeConfig })
+					.__RUNTIME_CONFIG__
+			).toEqual(config);
+			return Promise.resolve({ data: payload });
+		});
 
-                expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledTimes(1);
-                expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
+		const { result } = await executeLoad(inviteCode);
 
-                const loadResult = result as Record<string, unknown>;
-                expect(loadResult.invite).toEqual(payload);
-                expect(loadResult.inviteState).toBe('ok');
-        });
+		expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledTimes(1);
+		expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
 
-        it('marks the invite as not found when the API returns a 404 status', async () => {
-                const inviteCode = 'missing';
+		const loadResult = result as Record<string, unknown>;
+		expect(loadResult.invite).toEqual(payload);
+		expect(loadResult.inviteState).toBe('ok');
+	});
 
-                setupWindowWithImmediateConfig({ PUBLIC_API_BASE_URL: '' });
-                guildInvitesReceiveInviteCodeGetMock.mockRejectedValue({
-                        isAxiosError: true,
-                        response: { status: 404 }
-                });
+	it('marks the invite as not found when the API returns a 404 status', async () => {
+		const inviteCode = 'missing';
 
-                const { result } = await executeLoad(inviteCode);
+		setupWindowWithImmediateConfig({ PUBLIC_API_BASE_URL: '' });
+		guildInvitesReceiveInviteCodeGetMock.mockRejectedValue({
+			isAxiosError: true,
+			response: { status: 404 }
+		});
 
-                expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
+		const { result } = await executeLoad(inviteCode);
 
-                const loadResult = result as Record<string, unknown>;
-                expect(loadResult.invite).toBeNull();
-                expect(loadResult.inviteState).toBe('not-found');
-        });
+		expect(guildInvitesReceiveInviteCodeGetMock).toHaveBeenCalledWith({ inviteCode });
+
+		const loadResult = result as Record<string, unknown>;
+		expect(loadResult.invite).toBeNull();
+		expect(loadResult.inviteState).toBe('not-found');
+	});
 });


### PR DESCRIPTION
## Summary
- restyle the invite route to use a single centered panel with guild avatar, member count, and join button
- extract reusable helpers for invite display and acceptance logic, including loading state handling
- cover invite utilities with Vitest specs while keeping existing load tests up to date

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce3f71521c8322afa082735ea3774e