### PR TITLE
feat: linkify chat URLs with invite previews

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -162,5 +162,17 @@
         "invite_not_found_title": "Einladung nicht verfügbar",
 	"invite_not_found_message": "Diese Einladung ist ungültig oder abgelaufen.",
 	"invite_member_count": "{count} Mitglieder",
+        "invite_preview_default_name": "GoChat community",
+        "invite_preview_loading": "Loading invite...",
+        "invite_preview_error_loading": "We couldn't load this invite.",
+        "invite_preview_open_link": "Open invite link",
+        "invite_preview_member_unknown": "Member count unavailable",
+        "invite_preview_member_one": "{count} member",
+        "invite_preview_member_other": "{count} members",
+        "invite_preview_accept": "Accept invite",
+        "invite_preview_accepting": "Accepting...",
+        "invite_preview_joined": "Joined",
+        "invite_preview_error_accept": "We couldn't join this guild.",
+        "invite_preview_invalid": "This invite may be invalid or expired.",
 	"connection_status_reconnecting": "Verbindungsprobleme. Stelle Chat-Verbindung wieder her…"
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -169,6 +169,7 @@
         "invite_preview_member_unknown": "Member count unavailable",
         "invite_preview_member_one": "{count} member",
         "invite_preview_member_other": "{count} members",
+        "invite_preview_created": "Erstellt am {date}",
         "invite_preview_accept": "Accept invite",
         "invite_preview_accepting": "Accepting...",
         "invite_preview_joined": "Joined",

--- a/messages/en.json
+++ b/messages/en.json
@@ -201,6 +201,7 @@
         "invite_preview_member_unknown": "Member count unavailable",
         "invite_preview_member_one": "{count} member",
         "invite_preview_member_other": "{count} members",
+        "invite_preview_created": "Created {date}",
         "invite_preview_accept": "Accept invite",
         "invite_preview_accepting": "Accepting...",
         "invite_preview_joined": "Joined",

--- a/messages/en.json
+++ b/messages/en.json
@@ -194,5 +194,17 @@
         "invite_not_found_title": "Invite unavailable",
 	"invite_not_found_message": "This invite is invalid or has expired.",
 	"invite_member_count": "{count} members",
+        "invite_preview_default_name": "GoChat community",
+        "invite_preview_loading": "Loading invite...",
+        "invite_preview_error_loading": "We couldn't load this invite.",
+        "invite_preview_open_link": "Open invite link",
+        "invite_preview_member_unknown": "Member count unavailable",
+        "invite_preview_member_one": "{count} member",
+        "invite_preview_member_other": "{count} members",
+        "invite_preview_accept": "Accept invite",
+        "invite_preview_accepting": "Accepting...",
+        "invite_preview_joined": "Joined",
+        "invite_preview_error_accept": "We couldn't join this guild.",
+        "invite_preview_invalid": "This invite may be invalid or expired.",
 	"connection_status_reconnecting": "Experiencing connection issues. Reconnecting to chat…"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -162,5 +162,17 @@
         "invite_not_found_title": "Invitation indisponible",
 	"invite_not_found_message": "Cette invitation est invalide ou a expiré.",
 	"invite_member_count": "{count} membres",
+        "invite_preview_default_name": "GoChat community",
+        "invite_preview_loading": "Loading invite...",
+        "invite_preview_error_loading": "We couldn't load this invite.",
+        "invite_preview_open_link": "Open invite link",
+        "invite_preview_member_unknown": "Member count unavailable",
+        "invite_preview_member_one": "{count} member",
+        "invite_preview_member_other": "{count} members",
+        "invite_preview_accept": "Accept invite",
+        "invite_preview_accepting": "Accepting...",
+        "invite_preview_joined": "Joined",
+        "invite_preview_error_accept": "We couldn't join this guild.",
+        "invite_preview_invalid": "This invite may be invalid or expired.",
 	"connection_status_reconnecting": "Problèmes de connexion. Reconnexion au chat…"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -169,6 +169,7 @@
         "invite_preview_member_unknown": "Member count unavailable",
         "invite_preview_member_one": "{count} member",
         "invite_preview_member_other": "{count} members",
+        "invite_preview_created": "Créé le {date}",
         "invite_preview_accept": "Accept invite",
         "invite_preview_accepting": "Accepting...",
         "invite_preview_joined": "Joined",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -194,5 +194,17 @@
         "invite_not_found_title": "Приглашение недоступно",
 	"invite_not_found_message": "Приглашение недействительно или срок его действия истёк.",
 	"invite_member_count": "{count} участников",
+        "invite_preview_default_name": "GoChat community",
+        "invite_preview_loading": "Loading invite...",
+        "invite_preview_error_loading": "We couldn't load this invite.",
+        "invite_preview_open_link": "Open invite link",
+        "invite_preview_member_unknown": "Member count unavailable",
+        "invite_preview_member_one": "{count} member",
+        "invite_preview_member_other": "{count} members",
+        "invite_preview_accept": "Accept invite",
+        "invite_preview_accepting": "Accepting...",
+        "invite_preview_joined": "Joined",
+        "invite_preview_error_accept": "We couldn't join this guild.",
+        "invite_preview_invalid": "This invite may be invalid or expired.",
 	"connection_status_reconnecting": "Возникли проблемы с соединением. Переподключаемся к чату…"
 }

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -201,6 +201,7 @@
         "invite_preview_member_unknown": "Member count unavailable",
         "invite_preview_member_one": "{count} member",
         "invite_preview_member_other": "{count} members",
+        "invite_preview_created": "Создан {date}",
         "invite_preview_accept": "Accept invite",
         "invite_preview_accepting": "Accepting...",
         "invite_preview_joined": "Joined",

--- a/src/lib/components/app/chat/InvitePreview.svelte
+++ b/src/lib/components/app/chat/InvitePreview.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+	import type { DtoInvitePreview } from '$lib/api';
+	import { auth } from '$lib/stores/auth';
+	import { m } from '$lib/paraglide/messages.js';
+	import { computeApiBase } from '$lib/runtime/api';
+
+	let { code, url } = $props<{ code: string; url: string }>();
+
+	let preview = $state<DtoInvitePreview | null>(null);
+	let loading = $state(false);
+	let loadError = $state<string | null>(null);
+	let accepting = $state(false);
+	let acceptError = $state<string | null>(null);
+	let accepted = $state(false);
+
+	const numberFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 0 });
+
+	function getGuildName(current: DtoInvitePreview | null): string {
+		const name = current?.guild?.name?.trim();
+		if (name) return name;
+		return m.invite_preview_default_name();
+	}
+
+	function getGuildInitials(name: string): string {
+		const parts = name.split(/\s+/).filter(Boolean).slice(0, 2);
+		if (parts.length === 0) return '?';
+		return parts.map((part) => part[0]?.toUpperCase() ?? '').join('') || '?';
+	}
+
+	const guildName = $derived(getGuildName(preview));
+	const guildInitials = $derived(getGuildInitials(guildName));
+	const guildIconUrl = $derived.by(() => {
+		const iconId = preview?.guild?.icon;
+		if (iconId == null) return null;
+		const base = computeApiBase();
+		return `${base.replace(/\/$/, '')}/attachments/${iconId}`;
+	});
+	const memberLabel = $derived.by(() => {
+		const count = preview?.members_count;
+		if (count == null) {
+			return m.invite_preview_member_unknown();
+		}
+		const formatted = numberFormatter.format(count);
+		if (count === 1) {
+			return m.invite_preview_member_one({ count: formatted });
+		}
+		return m.invite_preview_member_other({ count: formatted });
+	});
+	const hostLabel = $derived.by(() => {
+		try {
+			return new URL(url).host;
+		} catch {
+			return null;
+		}
+	});
+
+	async function loadPreview() {
+		if (!code) {
+			preview = null;
+			return;
+		}
+		loading = true;
+		loadError = null;
+		preview = null;
+		try {
+			const res = await auth.api.guildInvites.guildInvitesReceiveInviteCodeGet({
+				inviteCode: code
+			});
+			preview = res.data ?? null;
+			if (!preview) {
+				loadError = m.invite_preview_error_loading();
+			}
+		} catch (error) {
+			const err = error as {
+				response?: { data?: { message?: string } };
+				message?: string;
+			};
+			loadError = err?.response?.data?.message ?? err?.message ?? m.invite_preview_error_loading();
+			preview = null;
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function acceptInvite() {
+		if (!code || accepting || accepted) return;
+		accepting = true;
+		acceptError = null;
+		try {
+			await auth.api.guildInvites.guildInvitesAcceptInviteCodePost({ inviteCode: code });
+			await auth.loadGuilds().catch(() => {});
+			accepted = true;
+		} catch (error) {
+			const err = error as {
+				response?: { data?: { message?: string } };
+				message?: string;
+			};
+			acceptError = err?.response?.data?.message ?? err?.message ?? m.invite_preview_error_accept();
+		} finally {
+			accepting = false;
+		}
+	}
+
+	$effect(() => {
+		code;
+		url;
+		acceptError = null;
+		accepted = false;
+		void loadPreview();
+	});
+</script>
+
+<div
+	class="rounded-lg border border-[var(--stroke)] bg-[var(--panel-strong)] p-3 text-sm text-[var(--text)] shadow-[var(--shadow-1)]"
+>
+	{#if loading}
+		<p class="text-xs text-[var(--muted)]">{m.invite_preview_loading()}</p>
+	{:else if loadError}
+		<div class="space-y-2">
+			<p class="text-xs text-[var(--muted)]">{loadError}</p>
+			<a
+				class="inline-flex w-fit items-center gap-1 text-xs font-medium text-[var(--brand)] underline underline-offset-2 transition hover:text-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none"
+				href={url}
+				rel="noopener noreferrer"
+				target="_blank"
+			>
+				{m.invite_preview_open_link()}
+			</a>
+		</div>
+	{:else if preview}
+		<div class="flex items-center gap-3">
+			<div
+				class="grid h-12 w-12 shrink-0 place-items-center overflow-hidden rounded-xl border border-[var(--stroke)] bg-[var(--panel)] text-base font-semibold"
+			>
+				{#if guildIconUrl}
+					<img alt={guildName} class="h-full w-full object-cover" src={guildIconUrl} />
+				{:else}
+					<span>{guildInitials}</span>
+				{/if}
+			</div>
+			<div class="min-w-0 flex-1">
+				<div class="truncate font-semibold">{guildName}</div>
+				<div class="text-xs text-[var(--muted)]">{memberLabel}</div>
+				{#if hostLabel}
+					<div class="text-xs text-[var(--muted)]">{hostLabel}</div>
+				{/if}
+			</div>
+			<button
+				class="rounded-md bg-[var(--brand)] px-3 py-1.5 text-xs font-semibold text-[var(--bg)] transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+				disabled={accepted || accepting}
+				type="button"
+				onclick={acceptInvite}
+			>
+				{accepted
+					? m.invite_preview_joined()
+					: accepting
+						? m.invite_preview_accepting()
+						: m.invite_preview_accept()}
+			</button>
+		</div>
+		{#if acceptError}
+			<p class="mt-2 text-xs text-[var(--danger)]">{acceptError}</p>
+		{/if}
+	{:else}
+		<p class="text-xs text-[var(--muted)]">{m.invite_preview_invalid()}</p>
+	{/if}
+</div>

--- a/src/routes/app/i/[invite_code]/+page.svelte
+++ b/src/routes/app/i/[invite_code]/+page.svelte
@@ -124,7 +124,7 @@
 						class="h-11 w-full rounded-md bg-[var(--brand)] font-semibold text-[var(--bg)] transition hover:bg-[var(--brand-2)] focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
 						type="button"
 						disabled={inviteState !== 'ok' || joining}
-						on:click={handleJoin}
+						onclick={handleJoin}
 					>
 						{joining ? 'Joining…' : 'Join guild'}
 					</button>


### PR DESCRIPTION
## Summary
- parse message text to render links and show inline invite previews with Accept buttons
- add an InvitePreview component and localized strings backing the preview UI
- switch the invite join button to the modern `onclick` attribute to silence Svelte warnings

## Testing
- npm run lint *(fails: existing repository formatting issues in unrelated files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce5625af888322aa47d2cca80cf7ea