### PR TITLE
fix: restrict invite detection to same origin

### DIFF
--- a/src/lib/components/app/chat/MessageItem.spec.ts
+++ b/src/lib/components/app/chat/MessageItem.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { extractInvite } from './extractInvite';
+
+const originalWindow = (globalThis as any).window;
+const originalLocation = (globalThis as any).location;
+
+function setOrigin(origin: string) {
+        const parsed = new URL(origin);
+        const fakeLocation = {
+                origin: parsed.origin,
+                host: parsed.host,
+                protocol: parsed.protocol
+        };
+
+        (globalThis as any).window = { location: fakeLocation };
+        (globalThis as any).location = fakeLocation;
+}
+
+afterEach(() => {
+        if (originalWindow === undefined) {
+                delete (globalThis as any).window;
+        } else {
+                (globalThis as any).window = originalWindow;
+        }
+
+        if (originalLocation === undefined) {
+                delete (globalThis as any).location;
+        } else {
+                (globalThis as any).location = originalLocation;
+        }
+});
+
+describe('extractInvite', () => {
+        it('returns an invite when the URL matches the current origin', () => {
+                setOrigin('https://chat.example.com');
+
+                expect(extractInvite('https://chat.example.com/app/i/ABC123')).toEqual({ code: 'ABC123' });
+        });
+
+        it('returns null when the URL origin differs from the current origin', () => {
+                setOrigin('https://chat.example.com');
+
+                expect(extractInvite('https://another.example.com/app/i/ABC123')).toBeNull();
+        });
+
+        it('returns null when no location information is available', () => {
+                delete (globalThis as any).window;
+                delete (globalThis as any).location;
+
+                expect(extractInvite('https://chat.example.com/app/i/ABC123')).toBeNull();
+        });
+});

--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -6,7 +6,8 @@
 	import { contextMenu, copyToClipboard } from '$lib/stores/contextMenu';
 	import { m } from '$lib/paraglide/messages.js';
 	import CodeBlock from './CodeBlock.svelte';
-	import InvitePreview from './InvitePreview.svelte';
+        import InvitePreview from './InvitePreview.svelte';
+        import { extractInvite } from './extractInvite';
 
 	type MessageSegment =
 		| { type: 'text'; content: string }
@@ -106,27 +107,7 @@
 		return `https://${raw}`;
 	}
 
-	function extractInvite(url: string): { code: string } | null {
-		try {
-			const parsed = new URL(url);
-			const segments = parsed.pathname.split('/').filter(Boolean);
-			if (
-				segments.length >= 3 &&
-				segments[0]?.toLowerCase() === 'app' &&
-				segments[1]?.toLowerCase() === 'i'
-			) {
-				const code = segments[2];
-				if (code) {
-					return { code };
-				}
-			}
-		} catch {
-			return null;
-		}
-		return null;
-	}
-
-	function extractYouTube(url: string): { videoId: string } | null {
+        function extractYouTube(url: string): { videoId: string } | null {
 		try {
 			const parsed = new URL(url);
 			const host = parsed.hostname.toLowerCase();

--- a/src/lib/components/app/chat/extractInvite.ts
+++ b/src/lib/components/app/chat/extractInvite.ts
@@ -1,0 +1,52 @@
+export function extractInvite(url: string): { code: string } | null {
+        try {
+                const parsed = new URL(url);
+
+                const currentLocation =
+                        typeof window !== 'undefined' && window?.location
+                                ? window.location
+                                : typeof location !== 'undefined'
+                                  ? location
+                                  : null;
+
+                if (!currentLocation) {
+                        return null;
+                }
+
+                const origin = 'origin' in currentLocation ? currentLocation.origin : undefined;
+                const host = 'host' in currentLocation ? currentLocation.host : undefined;
+                const protocol = 'protocol' in currentLocation ? currentLocation.protocol : undefined;
+
+                if (origin) {
+                        if (parsed.origin !== origin) {
+                                return null;
+                        }
+                } else if (host) {
+                        if (parsed.host !== host) {
+                                return null;
+                        }
+
+                        if (protocol && parsed.protocol !== protocol) {
+                                return null;
+                        }
+                } else {
+                        return null;
+                }
+
+                const segments = parsed.pathname.split('/').filter(Boolean);
+                if (
+                        segments.length >= 3 &&
+                        segments[0]?.toLowerCase() === 'app' &&
+                        segments[1]?.toLowerCase() === 'i'
+                ) {
+                        const code = segments[2];
+                        if (code) {
+                                return { code };
+                        }
+                }
+        } catch {
+                return null;
+        }
+
+        return null;
+}


### PR DESCRIPTION
## Summary
- ensure chat invite detection only accepts links from the current origin
- share the invite extraction logic from a dedicated helper used by MessageItem
- add Vitest coverage for matching, mismatched, and missing origin scenarios

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce71e2359c8322b3b2f29e59bc8cb0