### PR TITLE
feat: add leave server confirmation modal

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -35,6 +35,8 @@
 	"rename_server": "Server umbenennen",
 	"server_settings": "Servereinstellungen",
 	"leave_server": "Server verlassen",
+	"leave_server_confirm_title": "„{server}“ verlassen?",
+	"leave_server_confirm_description": "Bist du sicher, dass du {server} verlassen möchtest? Du verlierst den Zugriff auf diesen Server und seine Kanäle.",
 	"copy_channel_id": "Kanal-ID kopieren",
 	"open_channel": "Kanal öffnen",
 	"delete_channel": "Kanal löschen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -67,6 +67,8 @@
 	"rename_server": "Rename server",
 	"server_settings": "Server settings",
 	"leave_server": "Leave server",
+	"leave_server_confirm_title": "Leave {server}?",
+	"leave_server_confirm_description": "Are you sure you want to leave {server}? You will lose access to this server and its channels.",
 	"copy_channel_id": "Copy channel ID",
 	"open_channel": "Open channel",
 	"delete_channel": "Delete channel",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -35,6 +35,8 @@
 	"rename_server": "Renommer le serveur",
 	"server_settings": "Paramètres du serveur",
 	"leave_server": "Quitter le serveur",
+	"leave_server_confirm_title": "Quitter {server} ?",
+	"leave_server_confirm_description": "Êtes-vous sûr de vouloir quitter {server} ? Vous perdrez l'accès à ce serveur et à ses salons.",
 	"copy_channel_id": "Copier l'ID du canal",
 	"open_channel": "Ouvrir le canal",
 	"delete_channel": "Supprimer le canal",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -67,6 +67,8 @@
 	"rename_server": "Переименовать сервер",
 	"server_settings": "Настройки сервера",
 	"leave_server": "Выйти с сервера",
+	"leave_server_confirm_title": "Покинуть {server}?",
+	"leave_server_confirm_description": "Вы уверены, что хотите покинуть {server}? Вы потеряете доступ к этому серверу и его каналам.",
 	"copy_channel_id": "Скопировать ID канала",
 	"open_channel": "Открыть канал",
 	"delete_channel": "Удалить канал",

--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -31,6 +31,7 @@
 	let creating = $state(false);
 	let newGuildName = $state('');
 	let error: string | null = $state(null);
+	let leavingGuild = $state<{ id: string; name: string } | null>(null);
 
 	async function createGuild() {
 		if (!newGuildName.trim()) return;
@@ -50,6 +51,16 @@
 			await auth.api.user.userMeGuildsGuildIdDelete({ guildId: gid as any });
 			await auth.loadGuilds();
 		} catch {}
+	}
+
+	async function confirmLeaveGuild() {
+		if (!leavingGuild) return;
+		const { id } = leavingGuild;
+		leavingGuild = null;
+		await leaveGuildDirect(id);
+		if ($selectedGuildId === id) {
+			selectedGuildId.set(null);
+		}
 	}
 
 	function openGuildSettings(gid: string) {
@@ -85,7 +96,13 @@
 						contextMenu.openFromEvent(e, [
 							{ label: m.copy_server_id(), action: () => copyToClipboard(gid) },
 							{ label: m.server_settings(), action: () => openGuildSettings(gid) },
-							{ label: m.leave_server(), action: () => leaveGuildDirect(gid), danger: true }
+							{
+								label: m.leave_server(),
+								action: () => {
+									leavingGuild = { id: gid, name };
+								},
+								danger: true
+							}
 						]);
 					}}
 				>
@@ -139,6 +156,44 @@
 						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
 						onclick={createGuild}>{m.create()}</button
 					>
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	{#if leavingGuild}
+		<div
+			class="fixed inset-0 z-50"
+			role="dialog"
+			tabindex="0"
+			onpointerdown={() => (leavingGuild = null)}
+			onkeydown={(e) => {
+				if (e.key === 'Escape') leavingGuild = null;
+				if (e.key === 'Enter') confirmLeaveGuild();
+			}}
+		>
+			<div class="absolute inset-0 bg-black/40"></div>
+			<div
+				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-4"
+				role="document"
+				tabindex="-1"
+				onpointerdown={(e) => e.stopPropagation()}
+			>
+				<div class="mb-2 text-base font-semibold">{m.leave_server_confirm_title({ server: leavingGuild.name })}</div>
+				<p class="mb-4 text-sm text-[var(--muted)]">{m.leave_server_confirm_description({ server: leavingGuild.name })}</p>
+				<div class="flex justify-end gap-2">
+					<button
+						class="rounded-md border border-[var(--stroke)] px-3 py-1"
+						onclick={() => (leavingGuild = null)}
+					>
+						{m.cancel()}
+					</button>
+					<button
+						class="rounded-md bg-[var(--danger)] px-3 py-1 text-[var(--bg)]"
+						onclick={confirmLeaveGuild}
+					>
+						{m.leave_server()}
+					</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- add state and confirmation workflow in the server bar before leaving a guild and clear the current selection after confirmation
- render a localized confirmation modal with keyboard handling and cancel/leave actions
- extend locale message files with leave-server confirmation strings

## Testing
- `npm run lint` *(fails: existing prettier formatting warnings across the repo)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ce8b45e38083229b5952d5b808b86c