### PR TITLE
fix: serve runtime env from base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The application will be available at http://localhost:3000.
 
 ### Runtime configuration
 
-At container start an entrypoint script writes `/usr/share/nginx/html/runtime-env.js` with the values of `PUBLIC_API_BASE_URL`, `PUBLIC_WS_URL` and `PUBLIC_BASE_PATH`. The page includes this script before the Svelte bundle loads, so browser code can discover deployment-specific endpoints without rebuilding the image.
+At container start an entrypoint script writes `/usr/share/nginx/html<base>/runtime-env.js` (where `<base>` is `PUBLIC_BASE_PATH` normalized the same way as SvelteKit's `paths.base`) with the values of `PUBLIC_API_BASE_URL`, `PUBLIC_WS_URL` and `PUBLIC_BASE_PATH`. The page includes this script before the Svelte bundle loads via `%sveltekit.base%/runtime-env.js`, so browser code can discover deployment-specific endpoints without rebuilding the image. A copy is also written to `/usr/share/nginx/html/runtime-env.js` for legacy consumers that still expect the root path.
 
 - Leave a variable unset (or empty) to fall back to the build-time value baked into the static bundle.
 - Override the defaults by passing environment variables to `docker run` (or your orchestrator):
@@ -96,7 +96,7 @@ At container start an entrypoint script writes `/usr/share/nginx/html/runtime-en
     gochatui
   ```
 
-The generated script is served as a static asset (`/runtime-env.js`), so the configuration is cached by browsers and CDNs just like other files. Restart the container after changing environment variables to refresh the runtime configuration.
+The generated script is served as a static asset (`<base>/runtime-env.js`), so the configuration is cached by browsers and CDNs just like other files. Restart the container after changing environment variables to refresh the runtime configuration.
 
 When deploying behind a reverse proxy that only forwards a sub-path, ensure that:
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,20 +1,52 @@
 #!/bin/sh
 set -eu
 
-OUTPUT="/usr/share/nginx/html/runtime-env.js"
+normalize_base_path() {
+  path=$1
+  # trim leading/trailing whitespace
+  trimmed=$(printf '%s' "${path}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  if [ -z "$trimmed" ] || [ "$trimmed" = "/" ]; then
+    printf '%s' ''
+    return
+  fi
+  case "$trimmed" in
+    /*) ;;
+    *) trimmed="/$trimmed" ;;
+  esac
+  # remove trailing slashes
+  trimmed=$(printf '%s' "$trimmed" | sed 's:/\+$::')
+  printf '%s' "$trimmed"
+}
 
-mkdir -p "$(dirname "$OUTPUT")"
+BASE_PATH=$(normalize_base_path "${PUBLIC_BASE_PATH-}")
+OUTPUT_DIR="/usr/share/nginx/html${BASE_PATH}"
+OUTPUT="${OUTPUT_DIR}/runtime-env.js"
+LEGACY_OUTPUT="/usr/share/nginx/html/runtime-env.js"
+
+mkdir -p "$OUTPUT_DIR"
+mkdir -p "$(dirname "$LEGACY_OUTPUT")"
 
 api_json=$(printf '%s' "${PUBLIC_API_BASE_URL-}" | jq -R .)
 ws_json=$(printf '%s' "${PUBLIC_WS_URL-}" | jq -R .)
 base_path_json=$(printf '%s' "${PUBLIC_BASE_PATH-}" | jq -R .)
 
-cat <<RUNTIME_EOF > "$OUTPUT"
+tmpfile=$(mktemp)
+trap 'rm -f "$tmpfile"' EXIT
+
+cat <<RUNTIME_EOF > "$tmpfile"
 window.__RUNTIME_CONFIG__ = {
   PUBLIC_BASE_PATH: ${base_path_json},
   PUBLIC_API_BASE_URL: ${api_json},
   PUBLIC_WS_URL: ${ws_json}
 };
 RUNTIME_EOF
+
+cp "$tmpfile" "$OUTPUT"
+
+if [ -n "$BASE_PATH" ]; then
+  cp "$tmpfile" "$LEGACY_OUTPUT"
+fi
+
+rm -f "$tmpfile"
 
 exec "$@"

--- a/src/app.html
+++ b/src/app.html
@@ -7,7 +7,7 @@
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 		<link href="https://cdn.jsdelivr.net/npm/remixicon@3.5.0/fonts/remixicon.css" rel="stylesheet" />
-		<script src="/runtime-env.js" defer></script>
+                <script src="%sveltekit.base%/runtime-env.js" defer></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
## Summary
- load the runtime configuration script through the SvelteKit base path
- emit runtime-env.js into the normalized PUBLIC_BASE_PATH directory while keeping a legacy root copy
- document the updated runtime configuration asset location

## Testing
- npm run lint *(fails: repository already contains numerous Prettier formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68cec02f49bc832281292d674d5074fa