### PR TITLE
fix: avoid duplicate inline parsing

### DIFF
--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -355,6 +355,7 @@
 
                         if (startIndex === -1) {
                                 parsePlainText(content.slice(cursor), tokens);
+                                cursor = content.length;
                                 break;
                         }
 
@@ -362,6 +363,7 @@
 
                         if (endIndex === -1) {
                                 parsePlainText(content.slice(cursor), tokens);
+                                cursor = content.length;
                                 break;
                         }
 


### PR DESCRIPTION
## Summary
- stop `parseInline` from invoking `parsePlainText` twice when no backtick spans exist by advancing the cursor to the end of the string before breaking
- ensure markdown-only emphasis messages are parsed once by preventing duplicate plain-text parsing

## Testing
- npm run lint *(fails: repository has numerous existing Prettier formatting issues)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfbcae90c88322b9a09b8cafcd817e