### PR TITLE
fix: default role permissions in manager

### DIFF
--- a/src/lib/components/app/settings/GuildRolesManager.svelte
+++ b/src/lib/components/app/settings/GuildRolesManager.svelte
@@ -190,6 +190,20 @@
                 }
         ];
 
+        const DEFAULT_ROLE_PERMISSIONS =
+                (1 << 0) |
+                (1 << 5) |
+                (1 << 6) |
+                (1 << 11) |
+                (1 << 12) |
+                (1 << 13) |
+                (1 << 14) |
+                (1 << 15) |
+                (1 << 19) |
+                (1 << 20) |
+                (1 << 21) |
+                (1 << 22);
+
         const DEFAULT_ROLE_COLOR = '#5865F2';
 
         let roles = $state<DtoRole[]>([]);
@@ -284,7 +298,7 @@
                 return {
                         name: '',
                         color: DEFAULT_ROLE_COLOR,
-                        permissions: 0
+                        permissions: DEFAULT_ROLE_PERMISSIONS
                 };
         }
 


### PR DESCRIPTION
## Summary
- add a DEFAULT_ROLE_PERMISSIONS bitmask matching the backend defaults
- initialize new guild role drafts with the default permissions so toggles start enabled

## Testing
- npm run lint *(fails: existing Prettier warnings in unrelated files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cfe2169d088322b11ac5cd20a5535b