### PR TITLE
fix: allow manage guild access to roles settings

### DIFF
--- a/src/lib/components/app/settings/GuildSettingsOverlay.svelte
+++ b/src/lib/components/app/settings/GuildSettingsOverlay.svelte
@@ -32,7 +32,14 @@
                 if (hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD)) {
                         allowed.push('profile');
                 }
-                if (hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_ROLES)) {
+                if (
+                        hasAnyGuildPermission(
+                                guild,
+                                $me?.id,
+                                PERMISSION_MANAGE_ROLES,
+                                PERMISSION_MANAGE_GUILD
+                        )
+                ) {
                         allowed.push('roles');
                 }
                 if (


### PR DESCRIPTION
## Summary
- allow guild members with Manage Server or Manage Roles permissions to access the Roles settings tab by checking both masks via `hasAnyGuildPermission`

## Testing
- npm run lint *(fails: existing Prettier formatting issues across repository)*
- npm run check *(fails: existing missing `DtoRole` type errors in MessageItem.svelte)*
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d0337ac5b88322bec6a95f2dd848b4