### PR TITLE
fix: allow role updates after closing context menu

### DIFF
--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -830,7 +830,6 @@ async function loadMemberRoleIds(guildId: string, userId: string): Promise<Set<s
                                                 label: labelForState(memberRoleIds.has(rid))
                                         };
                                         item.action = async () => {
-                                                if (!allowRefresh) return;
                                                 const assigned = memberRoleIds.has(rid);
                                                 let roleSnowflake: any;
                                                 try {


### PR DESCRIPTION
## Summary
- allow message user role toggles to continue executing even after the context menu closes

## Testing
- npm run lint *(fails: Prettier reports existing formatting issues across the repository)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0424c1d248322b87094b7ca51170e