### PR TITLE
feat: color chat usernames using guild roles

### DIFF
--- a/src/lib/components/app/settings/GuildRolesManager.svelte
+++ b/src/lib/components/app/settings/GuildRolesManager.svelte
@@ -10,6 +10,7 @@
                 type PermissionCategory,
                 type PermissionDefinition
         } from '$lib/utils/permissionDefinitions';
+        import { colorIntToHex } from '$lib/utils/color';
 
         type RoleDraft = {
                 name: string;
@@ -85,19 +86,6 @@
                 return DEFAULT_ROLE_COLOR;
         }
 
-        function toHex(color?: number | string | null): string {
-                const numeric =
-                        typeof color === 'string'
-                                ? Number(color)
-                                : typeof color === 'number'
-                                        ? color
-                                        : 0;
-                if (!Number.isFinite(numeric) || numeric < 0) {
-                        return '#000000';
-                }
-                return `#${Math.round(numeric).toString(16).padStart(6, '0').toUpperCase()}`;
-        }
-
         function colorIntFromHex(hex: string): number {
                 const cleaned = hex.startsWith('#') ? hex.slice(1) : hex;
                 const parsed = parseInt(cleaned, 16);
@@ -110,13 +98,13 @@
         }
 
         function roleColor(role: DtoRole): string {
-                return normalizeHex(toHex(role?.color));
+                return normalizeHex(colorIntToHex(role?.color));
         }
 
         function createDraftFromRole(role?: DtoRole | null): RoleDraft {
                 return {
                         name: role?.name ?? '',
-                        color: normalizeHex(toHex(role?.color)),
+                        color: normalizeHex(colorIntToHex(role?.color)),
                         permissions: role?.permissions != null ? Number(role.permissions) : 0
                 };
         }

--- a/src/lib/utils/color.ts
+++ b/src/lib/utils/color.ts
@@ -1,0 +1,16 @@
+export function colorIntToHex(color?: number | string | bigint | null): string {
+	const numeric =
+		typeof color === 'bigint'
+			? Number(color)
+			: typeof color === 'string'
+				? Number(color)
+				: typeof color === 'number'
+					? color
+					: Number.NaN;
+
+	if (!Number.isFinite(numeric) || numeric < 0) {
+		return '#000000';
+	}
+
+	return `#${Math.round(numeric).toString(16).padStart(6, '0').toUpperCase()}`;
+}


### PR DESCRIPTION
## Summary
- derive the message author role ids on the chat item, load role metadata, and tint the username with the member's primary role color
- extract the integer-to-hex role color helper so it can be reused across components
- reuse the shared helper in the guild roles manager to keep color handling consistent

## Testing
- npm run lint *(fails: repository contains many existing files that do not satisfy prettier --check)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1c9fec8f483229bc0ae06257e13b1