### PR TITLE
feat: add shared settings panel

### DIFF
--- a/src/lib/components/app/settings/GuildSettingsOverlay.svelte
+++ b/src/lib/components/app/settings/GuildSettingsOverlay.svelte
@@ -1,109 +1,98 @@
 <script lang="ts">
-        import { guildSettingsOpen, selectedGuildId } from '$lib/stores/appState';
-        import { auth } from '$lib/stores/auth';
-        import { m } from '$lib/paraglide/messages.js';
-        import GuildInvitesManager from './GuildInvitesManager.svelte';
-        import GuildRolesManager from './GuildRolesManager.svelte';
-        import {
-                PERMISSION_BAN_MEMBERS,
-                PERMISSION_CREATE_INVITES,
-                PERMISSION_KICK_MEMBERS,
-                PERMISSION_MANAGE_CHANNELS,
-                PERMISSION_MANAGE_GUILD,
-                PERMISSION_MANAGE_ROLES,
-                PERMISSION_TIMEOUT_MEMBERS,
-                hasAnyGuildPermission,
-                hasGuildPermission
-        } from '$lib/utils/permissions';
+	import { guildSettingsOpen, selectedGuildId } from '$lib/stores/appState';
+	import { auth } from '$lib/stores/auth';
+	import { m } from '$lib/paraglide/messages.js';
+	import GuildInvitesManager from './GuildInvitesManager.svelte';
+	import GuildRolesManager from './GuildRolesManager.svelte';
+	import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
+	import {
+		PERMISSION_BAN_MEMBERS,
+		PERMISSION_CREATE_INVITES,
+		PERMISSION_KICK_MEMBERS,
+		PERMISSION_MANAGE_CHANNELS,
+		PERMISSION_MANAGE_GUILD,
+		PERMISSION_MANAGE_ROLES,
+		PERMISSION_TIMEOUT_MEMBERS,
+		hasAnyGuildPermission,
+		hasGuildPermission
+	} from '$lib/utils/permissions';
 
-        type SettingsCategory = 'profile' | 'roles' | 'moderation' | 'integrations' | 'invites';
+	type SettingsCategory = 'profile' | 'roles' | 'moderation' | 'integrations' | 'invites';
 
-        const guilds = auth.guilds;
-        const me = auth.user;
-        const activeGuild = $derived.by(() => {
-                const gid = $selectedGuildId;
-                if (!gid) return null;
-                return $guilds.find((g) => String((g as any)?.id) === gid) ?? null;
-        });
-        const accessibleCategories = $derived.by(() => {
-                const guild = activeGuild;
-                const allowed: SettingsCategory[] = [];
-                if (!guild) return allowed;
-                if (hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD)) {
-                        allowed.push('profile');
-                }
-                if (
-                        hasAnyGuildPermission(
-                                guild,
-                                $me?.id,
-                                PERMISSION_MANAGE_ROLES,
-                                PERMISSION_MANAGE_GUILD
-                        )
-                ) {
-                        allowed.push('roles');
-                }
-                if (
-                        hasAnyGuildPermission(
-                                guild,
-                                $me?.id,
-                                PERMISSION_MANAGE_GUILD,
-                                PERMISSION_KICK_MEMBERS,
-                                PERMISSION_BAN_MEMBERS,
-                                PERMISSION_TIMEOUT_MEMBERS
-                        )
-                ) {
-                        allowed.push('moderation');
-                }
-                if (hasGuildPermission(guild, $me?.id, PERMISSION_CREATE_INVITES)) {
-                        allowed.push('invites');
-                }
-                if (
-                        hasAnyGuildPermission(
-                                guild,
-                                $me?.id,
-                                PERMISSION_MANAGE_GUILD,
-                                PERMISSION_MANAGE_CHANNELS
-                        )
-                ) {
-                        allowed.push('integrations');
-                }
-                return allowed;
-        });
-        let category = $state<SettingsCategory>('profile');
-        let name = $state('');
-        let saving = $state(false);
-        let error: string | null = $state(null);
+	const guilds = auth.guilds;
+	const me = auth.user;
+	const activeGuild = $derived.by(() => {
+		const gid = $selectedGuildId;
+		if (!gid) return null;
+		return $guilds.find((g) => String((g as any)?.id) === gid) ?? null;
+	});
+	const accessibleCategories = $derived.by(() => {
+		const guild = activeGuild;
+		const allowed: SettingsCategory[] = [];
+		if (!guild) return allowed;
+		if (hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD)) {
+			allowed.push('profile');
+		}
+		if (hasAnyGuildPermission(guild, $me?.id, PERMISSION_MANAGE_ROLES, PERMISSION_MANAGE_GUILD)) {
+			allowed.push('roles');
+		}
+		if (
+			hasAnyGuildPermission(
+				guild,
+				$me?.id,
+				PERMISSION_MANAGE_GUILD,
+				PERMISSION_KICK_MEMBERS,
+				PERMISSION_BAN_MEMBERS,
+				PERMISSION_TIMEOUT_MEMBERS
+			)
+		) {
+			allowed.push('moderation');
+		}
+		if (hasGuildPermission(guild, $me?.id, PERMISSION_CREATE_INVITES)) {
+			allowed.push('invites');
+		}
+		if (
+			hasAnyGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD, PERMISSION_MANAGE_CHANNELS)
+		) {
+			allowed.push('integrations');
+		}
+		return allowed;
+	});
+	let category = $state<SettingsCategory>('profile');
+	let name = $state('');
+	let saving = $state(false);
+	let error: string | null = $state(null);
 
-        $effect(() => {
-                if ($guildSettingsOpen) {
-                        const current = activeGuild;
-                        name = current?.name ?? '';
-                        error = null;
-                        saving = false;
-                        const allowed = accessibleCategories;
-                        if (!allowed.length) {
-                                guildSettingsOpen.set(false);
-                                return;
-                        }
-                        if (!allowed.includes(category)) {
-                                category = allowed[0];
-                        }
-                }
-        });
+	$effect(() => {
+		if ($guildSettingsOpen) {
+			const current = activeGuild;
+			name = current?.name ?? '';
+			error = null;
+			saving = false;
+			const allowed = accessibleCategories;
+			if (!allowed.length) {
+				guildSettingsOpen.set(false);
+				return;
+			}
+			if (!allowed.includes(category)) {
+				category = allowed[0];
+			}
+		}
+	});
 
-        async function save() {
-                const guild = activeGuild;
-                const gid = $selectedGuildId;
-                if (!guild || !gid) return;
-                if (!hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD)) return;
-                saving = true;
-                error = null;
-                try {
-                        await auth.api.guild.guildGuildIdPatch({
-                                guildId: BigInt(gid) as any,
-                                guildUpdateGuildRequest: { name }
-                        });
-                        await auth.loadGuilds();
+	async function save() {
+		const guild = activeGuild;
+		const gid = $selectedGuildId;
+		if (!guild || !gid) return;
+		if (!hasGuildPermission(guild, $me?.id, PERMISSION_MANAGE_GUILD)) return;
+		saving = true;
+		error = null;
+		try {
+			await auth.api.guild.guildGuildIdPatch({
+				guildId: BigInt(gid) as any,
+				guildUpdateGuildRequest: { name }
+			});
+			await auth.loadGuilds();
 		} catch (e: any) {
 			error = e?.response?.data?.message ?? e?.message ?? 'Failed to save';
 		} finally {
@@ -111,112 +100,94 @@
 		}
 	}
 
-	function close() {
+	function closeOverlay() {
 		guildSettingsOpen.set(false);
 	}
 </script>
 
-<svelte:window on:keydown={(e) => $guildSettingsOpen && e.key === 'Escape' && close()} />
-{#if $guildSettingsOpen}
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-		onpointerdown={close}
-	>
-		<div
-			class="relative flex h-[80vh] w-full max-w-3xl overflow-hidden rounded-lg bg-[var(--bg)] shadow-xl"
-			onpointerdown={(e) => e.stopPropagation()}
-		>
+<SettingsPanel bind:open={$guildSettingsOpen} on:close={closeOverlay}>
+	<svelte:fragment slot="sidebar">
+		{#if accessibleCategories.includes('profile')}
 			<button
-				aria-label={m.close()}
-				class="absolute top-3 right-3 rounded p-1 text-xl leading-none hover:bg-[var(--panel)]"
-				onclick={close}
+				class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'profile'
+					? 'bg-[var(--panel)] font-semibold'
+					: ''}"
+				onclick={() => (category = 'profile')}
 			>
-				&times;
+				{m.server_profile()}
 			</button>
-                        <aside class="w-48 space-y-2 border-r border-[var(--stroke)] p-4">
-                                {#if accessibleCategories.includes('profile')}
-                                        <button
-                                                class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'profile'
-                                                        ? 'bg-[var(--panel)] font-semibold'
-                                                        : ''}"
-                                                onclick={() => (category = 'profile')}
-                                        >
-                                                {m.server_profile()}
-                                        </button>
-                                {/if}
-                                {#if accessibleCategories.includes('roles')}
-                                        <button
-                                                class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'roles'
-                                                        ? 'bg-[var(--panel)] font-semibold'
-                                                        : ''}"
-                                                onclick={() => (category = 'roles')}
-                                        >
-                                                {m.roles()}
-                                        </button>
-                                {/if}
-                                {#if accessibleCategories.includes('moderation')}
-                                        <button
-                                                class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'moderation'
-                                                        ? 'bg-[var(--panel)] font-semibold'
-                                                        : ''}"
-                                                onclick={() => (category = 'moderation')}
-                                        >
-                                                {m.moderation()}
-                                        </button>
-                                {/if}
-                                {#if accessibleCategories.includes('invites')}
-                                        <button
-                                                class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'invites'
-                                                        ? 'bg-[var(--panel)] font-semibold'
-                                                        : ''}"
-                                                onclick={() => (category = 'invites')}
-                                        >
-                                                {m.invites()}
-                                        </button>
-                                {/if}
-                                {#if accessibleCategories.includes('integrations')}
-                                        <button
-                                                class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'integrations'
-                                                        ? 'bg-[var(--panel)] font-semibold'
-                                                        : ''}"
-                                                onclick={() => (category = 'integrations')}
-                                        >
-                                                {m.integrations()}
-                                        </button>
-                                {/if}
-                        </aside>
-                        <section class="scroll-area flex-1 space-y-4 overflow-y-auto p-4">
-                                {#if category === 'profile' && accessibleCategories.includes('profile')}
-                                        <div>
-                                                <label for="guild-name" class="mb-2 block">{m.server_name()}</label>
-                                                <input
-							id="guild-name"
-							class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
-							bind:value={name}
-						/>
-						<div class="mt-2 flex gap-2">
-							<button
-								class="rounded bg-blue-500 px-3 py-1 text-white hover:bg-blue-600 disabled:opacity-50"
-								onclick={save}
-								disabled={saving}
-							>
-								{saving ? m.saving() : m.save()}
-							</button>
-						</div>
-						{#if error}
-							<p class="mt-2 text-sm text-red-500">{error}</p>
-						{/if}
-					</div>
-                                {:else if category === 'roles' && accessibleCategories.includes('roles')}
-                                        <GuildRolesManager />
-                                {:else if category === 'moderation' && accessibleCategories.includes('moderation')}
-                                        <p>{m.moderation()}...</p>
-                                {:else if category === 'invites' && accessibleCategories.includes('invites')}
-                                        <GuildInvitesManager />
-                                {:else if category === 'integrations' && accessibleCategories.includes('integrations')}
-                                        <p>{m.integrations()}...</p>
-                                {/if}
-                        </section>
+		{/if}
+		{#if accessibleCategories.includes('roles')}
+			<button
+				class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'roles'
+					? 'bg-[var(--panel)] font-semibold'
+					: ''}"
+				onclick={() => (category = 'roles')}
+			>
+				{m.roles()}
+			</button>
+		{/if}
+		{#if accessibleCategories.includes('moderation')}
+			<button
+				class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'moderation'
+					? 'bg-[var(--panel)] font-semibold'
+					: ''}"
+				onclick={() => (category = 'moderation')}
+			>
+				{m.moderation()}
+			</button>
+		{/if}
+		{#if accessibleCategories.includes('invites')}
+			<button
+				class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'invites'
+					? 'bg-[var(--panel)] font-semibold'
+					: ''}"
+				onclick={() => (category = 'invites')}
+			>
+				{m.invites()}
+			</button>
+		{/if}
+		{#if accessibleCategories.includes('integrations')}
+			<button
+				class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category ===
+				'integrations'
+					? 'bg-[var(--panel)] font-semibold'
+					: ''}"
+				onclick={() => (category = 'integrations')}
+			>
+				{m.integrations()}
+			</button>
+		{/if}
+	</svelte:fragment>
+
+	{#if category === 'profile' && accessibleCategories.includes('profile')}
+		<div>
+			<label for="guild-name" class="mb-2 block">{m.server_name()}</label>
+			<input
+				id="guild-name"
+				class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-blue-500 focus:outline-none"
+				bind:value={name}
+			/>
+			<div class="mt-2 flex gap-2">
+				<button
+					class="rounded bg-blue-500 px-3 py-1 text-white hover:bg-blue-600 disabled:opacity-50"
+					onclick={save}
+					disabled={saving}
+				>
+					{saving ? m.saving() : m.save()}
+				</button>
+			</div>
+			{#if error}
+				<p class="mt-2 text-sm text-red-500">{error}</p>
+			{/if}
 		</div>
-	</div>
-{/if}
+	{:else if category === 'roles' && accessibleCategories.includes('roles')}
+		<GuildRolesManager />
+	{:else if category === 'moderation' && accessibleCategories.includes('moderation')}
+		<p>{m.moderation()}...</p>
+	{:else if category === 'invites' && accessibleCategories.includes('invites')}
+		<GuildInvitesManager />
+	{:else if category === 'integrations' && accessibleCategories.includes('integrations')}
+		<p>{m.integrations()}...</p>
+	{/if}
+</SettingsPanel>

--- a/src/lib/components/app/settings/SettingsOverlay.svelte
+++ b/src/lib/components/app/settings/SettingsOverlay.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-        import { settingsOpen, theme, locale } from '$lib/stores/settings';
-        import { m } from '$lib/paraglide/messages.js';
-        import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
-        import type { Theme, Locale } from '$lib/stores/settings';
+	import { settingsOpen, theme, locale } from '$lib/stores/settings';
+	import { m } from '$lib/paraglide/messages.js';
+	import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
+	import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
+	import type { Theme, Locale } from '$lib/stores/settings';
 
 	type LanguageOption = {
 		code: Locale;
@@ -27,160 +28,136 @@
 		{ value: 'dark', label: () => m.dark() }
 	];
 
-        let category = $state<'profile' | 'general' | 'appearance' | 'other'>('profile');
+	let category = $state<'profile' | 'general' | 'appearance' | 'other'>('profile');
 
-	function close() {
+	function closeOverlay() {
 		settingsOpen.set(false);
 	}
 </script>
 
-<svelte:window on:keydown={(e) => $settingsOpen && e.key === 'Escape' && close()} />
-{#if $settingsOpen}
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-		onpointerdown={close}
-	>
-		<div
-			class="relative flex h-[80vh] w-full max-w-3xl overflow-hidden rounded-lg bg-[var(--bg)] shadow-xl"
-			onpointerdown={(e) => e.stopPropagation()}
+<SettingsPanel bind:open={$settingsOpen} on:close={closeOverlay}>
+	<svelte:fragment slot="sidebar">
+		<button
+			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'profile'
+				? 'bg-[var(--panel)] font-semibold'
+				: ''}"
+			onclick={() => (category = 'profile')}
 		>
-			<button
-				aria-label={m.close()}
-				class="absolute top-3 right-3 rounded p-1 text-xl leading-none hover:bg-[var(--panel)]"
-				onclick={close}
-			>
-				&times;
-			</button>
-			<aside class="w-48 space-y-2 border-r border-[var(--stroke)] p-4">
-                                <button
-                                        class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'profile'
-                                                ? 'bg-[var(--panel)] font-semibold'
-                                                : ''}"
-                                        onclick={() => (category = 'profile')}
-                                >
-                                        {m.profile()}
-                                </button>
-                                <button
-                                        class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'general'
-                                                ? 'bg-[var(--panel)] font-semibold'
-                                                : ''}"
-					onclick={() => (category = 'general')}
-				>
-					{m.general()}
-				</button>
-				<button
-					class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category ===
-					'appearance'
-						? 'bg-[var(--panel)] font-semibold'
-						: ''}"
-					onclick={() => (category = 'appearance')}
-				>
-					{m.appearance()}
-				</button>
-				<button
-					class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'other'
-						? 'bg-[var(--panel)] font-semibold'
-						: ''}"
-					onclick={() => (category = 'other')}
-				>
-					{m.other()}
-				</button>
-			</aside>
-                        <section class="scroll-area flex-1 space-y-4 overflow-y-auto p-4">
-                                {#if category === 'profile'}
-                                        <div class="space-y-4">
-                                                <ProfileEdit />
-                                        </div>
-                                {:else if category === 'general'}
-                                        <div>
-                                                <p id="language-group-label" class="mb-2 block">{m.language()}</p>
-						<div class="space-y-2" role="radiogroup" aria-labelledby="language-group-label">
-							{#each languages as lang (lang.code)}
-								<div>
-									<input
-										type="radio"
-										name="language"
-										id={`language-${lang.code}`}
-										class="sr-only"
-										value={lang.code}
-										checked={$locale === lang.code}
-										onchange={() => locale.set(lang.code)}
-									/>
-									<label
-										for={`language-${lang.code}`}
-										class={`flex w-full cursor-pointer items-center justify-between rounded-lg border px-4 py-3 transition select-none focus-within:ring-2 focus-within:ring-[var(--brand)]/60 focus-within:ring-offset-2 focus-within:ring-offset-[var(--bg)] ${
-											$locale === lang.code
-												? 'border-[var(--brand)] bg-[var(--panel-strong)] shadow-sm'
-												: 'border-[var(--stroke)] bg-[var(--panel)] hover:border-[var(--brand)]/60 hover:bg-[var(--panel-strong)]'
-										}`}
-									>
-										<span class="text-base font-medium">{lang.label}</span>
-										<span
-											class={`ml-4 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors duration-150 ${
-												$locale === lang.code
-													? 'border-[var(--success)]'
-													: 'border-[var(--stroke-2)]'
-											}`}
-											aria-hidden="true"
-										>
-											<span
-												class={`h-2.5 w-2.5 rounded-full transition-colors duration-150 ${
-													$locale === lang.code ? 'bg-[var(--success)]' : 'bg-transparent'
-												}`}
-											></span>
-										</span>
-									</label>
-								</div>
-							{/each}
-						</div>
-					</div>
-				{:else if category === 'appearance'}
-					<div>
-						<p id="theme-group-label" class="mb-2 block">{m.theme()}</p>
-						<div class="space-y-2" role="radiogroup" aria-labelledby="theme-group-label">
-							{#each themeOptions as option (option.value)}
-								<div>
-									<input
-										type="radio"
-										name="theme"
-										id={`theme-${option.value}`}
-										class="sr-only"
-										value={option.value}
-										checked={$theme === option.value}
-										onchange={() => theme.set(option.value)}
-									/>
-									<label
-										for={`theme-${option.value}`}
-										class={`flex w-full cursor-pointer items-center justify-between rounded-lg border px-4 py-3 transition select-none focus-within:ring-2 focus-within:ring-[var(--brand)]/60 focus-within:ring-offset-2 focus-within:ring-offset-[var(--bg)] ${
-											$theme === option.value
-												? 'border-[var(--brand)] bg-[var(--panel-strong)] shadow-sm'
-												: 'border-[var(--stroke)] bg-[var(--panel)] hover:border-[var(--brand)]/60 hover:bg-[var(--panel-strong)]'
-										}`}
-									>
-										<span class="text-base font-medium">{option.label()}</span>
-										<span
-											class={`ml-4 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors duration-150 ${
-												$theme === option.value
-													? 'border-[var(--brand)]'
-													: 'border-[var(--stroke-2)]'
-											}`}
-											aria-hidden="true"
-										>
-											<span
-												class={`h-2.5 w-2.5 rounded-full transition-colors duration-150 ${
-													$theme === option.value ? 'bg-[var(--brand)]' : 'bg-transparent'
-												}`}
-											></span>
-										</span>
-									</label>
-								</div>
-							{/each}
-						</div>
-					</div>
-				{:else}
-					<p>{m.other()}...</p>
-				{/if}
-			</section>
+			{m.profile()}
+		</button>
+		<button
+			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'general'
+				? 'bg-[var(--panel)] font-semibold'
+				: ''}"
+			onclick={() => (category = 'general')}
+		>
+			{m.general()}
+		</button>
+		<button
+			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'appearance'
+				? 'bg-[var(--panel)] font-semibold'
+				: ''}"
+			onclick={() => (category = 'appearance')}
+		>
+			{m.appearance()}
+		</button>
+		<button
+			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'other'
+				? 'bg-[var(--panel)] font-semibold'
+				: ''}"
+			onclick={() => (category = 'other')}
+		>
+			{m.other()}
+		</button>
+	</svelte:fragment>
+
+	{#if category === 'profile'}
+		<div class="space-y-4">
+			<ProfileEdit />
 		</div>
-	</div>
-{/if}
+	{:else if category === 'general'}
+		<div>
+			<p id="language-group-label" class="mb-2 block">{m.language()}</p>
+			<div class="space-y-2" role="radiogroup" aria-labelledby="language-group-label">
+				{#each languages as lang (lang.code)}
+					<div>
+						<input
+							type="radio"
+							name="language"
+							id={`language-${lang.code}`}
+							class="sr-only"
+							value={lang.code}
+							checked={$locale === lang.code}
+							onchange={() => locale.set(lang.code)}
+						/>
+						<label
+							for={`language-${lang.code}`}
+							class={`flex w-full cursor-pointer items-center justify-between rounded-lg border px-4 py-3 transition select-none focus-within:ring-2 focus-within:ring-[var(--brand)]/60 focus-within:ring-offset-2 focus-within:ring-offset-[var(--bg)] ${
+								$locale === lang.code
+									? 'border-[var(--brand)] bg-[var(--panel-strong)] shadow-sm'
+									: 'border-[var(--stroke)] bg-[var(--panel)] hover:border-[var(--brand)]/60 hover:bg-[var(--panel-strong)]'
+							}`}
+						>
+							<span class="text-base font-medium">{lang.label}</span>
+							<span
+								class={`ml-4 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors duration-150 ${
+									$locale === lang.code ? 'border-[var(--success)]' : 'border-[var(--stroke-2)]'
+								}`}
+								aria-hidden="true"
+							>
+								<span
+									class={`h-2.5 w-2.5 rounded-full transition-colors duration-150 ${
+										$locale === lang.code ? 'bg-[var(--success)]' : 'bg-transparent'
+									}`}
+								></span>
+							</span>
+						</label>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{:else if category === 'appearance'}
+		<div>
+			<p id="theme-group-label" class="mb-2 block">{m.theme()}</p>
+			<div class="space-y-2" role="radiogroup" aria-labelledby="theme-group-label">
+				{#each themeOptions as option (option.value)}
+					<div>
+						<input
+							type="radio"
+							name="theme"
+							id={`theme-${option.value}`}
+							class="sr-only"
+							value={option.value}
+							checked={$theme === option.value}
+							onchange={() => theme.set(option.value)}
+						/>
+						<label
+							for={`theme-${option.value}`}
+							class={`flex w-full cursor-pointer items-center justify-between rounded-lg border px-4 py-3 transition select-none focus-within:ring-2 focus-within:ring-[var(--brand)]/60 focus-within:ring-offset-2 focus-within:ring-offset-[var(--bg)] ${
+								$theme === option.value
+									? 'border-[var(--brand)] bg-[var(--panel-strong)] shadow-sm'
+									: 'border-[var(--stroke)] bg-[var(--panel)] hover:border-[var(--brand)]/60 hover:bg-[var(--panel-strong)]'
+							}`}
+						>
+							<span class="text-base font-medium">{option.label()}</span>
+							<span
+								class={`ml-4 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-colors duration-150 ${
+									$theme === option.value ? 'border-[var(--brand)]' : 'border-[var(--stroke-2)]'
+								}`}
+								aria-hidden="true"
+							>
+								<span
+									class={`h-2.5 w-2.5 rounded-full transition-colors duration-150 ${
+										$theme === option.value ? 'bg-[var(--brand)]' : 'bg-transparent'
+									}`}
+								></span>
+							</span>
+						</label>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{:else}
+		<p>{m.other()}...</p>
+	{/if}
+</SettingsPanel>

--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -20,6 +20,7 @@
 	import { contextMenu, copyToClipboard } from '$lib/stores/contextMenu';
 	import { m } from '$lib/paraglide/messages.js';
 	import UserPanel from '$lib/components/app/user/UserPanel.svelte';
+	import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
 	import { Check, FolderPlus, Plus, Settings, Slash, X } from 'lucide-svelte';
 	import { loadGuildRolesCached } from '$lib/utils/guildRoles';
 	import { CHANNEL_PERMISSION_CATEGORIES } from '$lib/utils/permissionDefinitions';
@@ -61,20 +62,20 @@
 	let editChannelName = $state('');
 	let editChannelTopic = $state('');
 	let editChannelPrivate = $state(false);
-        let editChannelError: string | null = $state(null);
-        let editChannelTab = $state<'overview' | 'permissions'>('overview');
-        let editChannelRoles = $state<DtoRole[]>([]);
-        let editChannelRoleToAdd = $state('');
-        let editChannelOverrides = $state<Record<string, { accept: number; deny: number }>>({});
-        let editChannelOverridesInitial = $state<Record<string, { accept: number; deny: number }>>({});
-        let editChannelSelectedOverride = $state<string | null>(null);
-        let editChannelOrderedOverrideRoleIds = $state<string[]>([]);
-        let editChannelPermissionsLoading = $state(false);
-        let editChannelPermissionsError: string | null = $state(null);
-        let editChannelInitialName = $state('');
-        let editChannelInitialTopic = $state('');
-        let editChannelInitialPrivate = $state(false);
-        let editChannelSaving = $state(false);
+	let editChannelError: string | null = $state(null);
+	let editChannelTab = $state<'overview' | 'permissions'>('overview');
+	let editChannelRoles = $state<DtoRole[]>([]);
+	let editChannelRoleToAdd = $state('');
+	let editChannelOverrides = $state<Record<string, { accept: number; deny: number }>>({});
+	let editChannelOverridesInitial = $state<Record<string, { accept: number; deny: number }>>({});
+	let editChannelSelectedOverride = $state<string | null>(null);
+	let editChannelOrderedOverrideRoleIds = $state<string[]>([]);
+	let editChannelPermissionsLoading = $state(false);
+	let editChannelPermissionsError: string | null = $state(null);
+	let editChannelInitialName = $state('');
+	let editChannelInitialTopic = $state('');
+	let editChannelInitialPrivate = $state(false);
+	let editChannelSaving = $state(false);
 	let editCategoryName = $state('');
 	let editCategoryError: string | null = $state(null);
 	let dragging: { id: string; parent: string | null; type: number } | null = null;
@@ -492,32 +493,32 @@
 		contextMenu.openFromEvent(e, items);
 	}
 
-        function openEditChannel(ch: DtoChannel) {
-                editingChannel = ch;
-                const name = ch.name ?? '';
-                const topic = (ch as any).topic ?? '';
-                const isPrivate = !!(ch as any).private;
-                editChannelName = name;
-                editChannelTopic = topic;
-                editChannelPrivate = isPrivate;
-                editChannelInitialName = name;
-                editChannelInitialTopic = topic;
-                editChannelInitialPrivate = isPrivate;
-                editChannelError = null;
-                editChannelTab = 'overview';
-                editChannelRoleToAdd = '';
-                editChannelPermissionsError = null;
-                editChannelOverrides = {};
-                editChannelOverridesInitial = {};
-                editChannelSelectedOverride = null;
-                editChannelOrderedOverrideRoleIds = [];
-                editChannelRoles = [];
-                editChannelSaving = false;
-                const channelId = String((ch as any)?.id ?? '');
-                if (channelId) {
-                        loadChannelPermissions(channelId);
-                }
-        }
+	function openEditChannel(ch: DtoChannel) {
+		editingChannel = ch;
+		const name = ch.name ?? '';
+		const topic = (ch as any).topic ?? '';
+		const isPrivate = !!(ch as any).private;
+		editChannelName = name;
+		editChannelTopic = topic;
+		editChannelPrivate = isPrivate;
+		editChannelInitialName = name;
+		editChannelInitialTopic = topic;
+		editChannelInitialPrivate = isPrivate;
+		editChannelError = null;
+		editChannelTab = 'overview';
+		editChannelRoleToAdd = '';
+		editChannelPermissionsError = null;
+		editChannelOverrides = {};
+		editChannelOverridesInitial = {};
+		editChannelSelectedOverride = null;
+		editChannelOrderedOverrideRoleIds = [];
+		editChannelRoles = [];
+		editChannelSaving = false;
+		const channelId = String((ch as any)?.id ?? '');
+		if (channelId) {
+			loadChannelPermissions(channelId);
+		}
+	}
 
 	function channelPermissionState(roleId: string, value: number): 'deny' | 'inherit' | 'allow' {
 		const override = editChannelOverrides[roleId];
@@ -598,11 +599,11 @@
 		});
 	}
 
-        function orderedOverrideRoleIds(): string[] {
-                const ids = Object.keys(editChannelOverrides);
-                if (!ids.length) {
-                        if (editChannelOrderedOverrideRoleIds.length) {
-                                editChannelOrderedOverrideRoleIds = [];
+	function orderedOverrideRoleIds(): string[] {
+		const ids = Object.keys(editChannelOverrides);
+		if (!ids.length) {
+			if (editChannelOrderedOverrideRoleIds.length) {
+				editChannelOrderedOverrideRoleIds = [];
 			}
 			return ids;
 		}
@@ -621,87 +622,87 @@
 		}
 		for (const id of remaining) {
 			next.push(id);
-                }
-                if (
-                        next.length !== editChannelOrderedOverrideRoleIds.length ||
-                        next.some((id, index) => editChannelOrderedOverrideRoleIds[index] !== id)
-                ) {
-                        editChannelOrderedOverrideRoleIds = next;
-                }
-                return next;
-        }
+		}
+		if (
+			next.length !== editChannelOrderedOverrideRoleIds.length ||
+			next.some((id, index) => editChannelOrderedOverrideRoleIds[index] !== id)
+		) {
+			editChannelOrderedOverrideRoleIds = next;
+		}
+		return next;
+	}
 
-        function hasEditChannelChanges(): boolean {
-                if (!editingChannel) return false;
-                if (editChannelName !== editChannelInitialName) return true;
-                if (editChannelTopic !== editChannelInitialTopic) return true;
-                if (editChannelPrivate !== editChannelInitialPrivate) return true;
-                const currentIds = Object.keys(editChannelOverrides);
-                const initialIds = Object.keys(editChannelOverridesInitial);
-                if (currentIds.length !== initialIds.length) return true;
-                for (const roleId of new Set([...currentIds, ...initialIds])) {
-                        const current = editChannelOverrides[roleId];
-                        const initial = editChannelOverridesInitial[roleId];
-                        if (!current && initial) return true;
-                        if (current && !initial) return true;
-                        if (!current || !initial) continue;
-                        if (current.accept !== initial.accept || current.deny !== initial.deny) {
-                                return true;
-                        }
-                }
-                return false;
-        }
+	function hasEditChannelChanges(): boolean {
+		if (!editingChannel) return false;
+		if (editChannelName !== editChannelInitialName) return true;
+		if (editChannelTopic !== editChannelInitialTopic) return true;
+		if (editChannelPrivate !== editChannelInitialPrivate) return true;
+		const currentIds = Object.keys(editChannelOverrides);
+		const initialIds = Object.keys(editChannelOverridesInitial);
+		if (currentIds.length !== initialIds.length) return true;
+		for (const roleId of new Set([...currentIds, ...initialIds])) {
+			const current = editChannelOverrides[roleId];
+			const initial = editChannelOverridesInitial[roleId];
+			if (!current && initial) return true;
+			if (current && !initial) return true;
+			if (!current || !initial) continue;
+			if (current.accept !== initial.accept || current.deny !== initial.deny) {
+				return true;
+			}
+		}
+		return false;
+	}
 
-        const editChannelHasChanges = $derived.by(() => hasEditChannelChanges());
+	const editChannelHasChanges = $derived.by(() => hasEditChannelChanges());
 
-        async function saveChannelPermissionOverrides(gid: string, channelId: string) {
-                const updates: Promise<any>[] = [];
-                const roleIds = new Set([
-                        ...Object.keys(editChannelOverridesInitial),
-                        ...Object.keys(editChannelOverrides)
-                ]);
-                for (const roleId of roleIds) {
-                        if (!roleId) continue;
-                        const next = editChannelOverrides[roleId];
-                        const initial = editChannelOverridesInitial[roleId];
-                        const hasNext = next != null;
-                        const hasInitial = initial != null;
-                        const nextAccept = next?.accept ?? 0;
-                        const nextDeny = next?.deny ?? 0;
-                        const initialAccept = initial?.accept ?? 0;
-                        const initialDeny = initial?.deny ?? 0;
-                        const baseParams = {
-                                guildId: toApiSnowflake(gid),
-                                channelId: toApiSnowflake(channelId),
-                                roleId: toApiSnowflake(roleId)
-                        } as const;
-                        if (!hasNext && hasInitial) {
-                                updates.push(
-                                        auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdDelete({
-                                                ...baseParams
-                                        })
-                                );
-                                continue;
-                        }
-                        if (hasNext && !hasInitial) {
-                                updates.push(
-                                        auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdPut({
-                                                ...baseParams,
-                                                guildChannelRolePermissionRequest: {
-                                                        accept: nextAccept,
-                                                        deny: nextDeny
-                                                } as any
-                                        })
-                                );
-                                continue;
-                        }
-                        if (!hasNext && !hasInitial) continue;
-                        if (nextAccept === initialAccept && nextDeny === initialDeny) continue;
-                        if (nextAccept === 0 && nextDeny === 0) {
-                                updates.push(
-                                        auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdDelete({
-                                                ...baseParams
-                                        })
+	async function saveChannelPermissionOverrides(gid: string, channelId: string) {
+		const updates: Promise<any>[] = [];
+		const roleIds = new Set([
+			...Object.keys(editChannelOverridesInitial),
+			...Object.keys(editChannelOverrides)
+		]);
+		for (const roleId of roleIds) {
+			if (!roleId) continue;
+			const next = editChannelOverrides[roleId];
+			const initial = editChannelOverridesInitial[roleId];
+			const hasNext = next != null;
+			const hasInitial = initial != null;
+			const nextAccept = next?.accept ?? 0;
+			const nextDeny = next?.deny ?? 0;
+			const initialAccept = initial?.accept ?? 0;
+			const initialDeny = initial?.deny ?? 0;
+			const baseParams = {
+				guildId: toApiSnowflake(gid),
+				channelId: toApiSnowflake(channelId),
+				roleId: toApiSnowflake(roleId)
+			} as const;
+			if (!hasNext && hasInitial) {
+				updates.push(
+					auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdDelete({
+						...baseParams
+					})
+				);
+				continue;
+			}
+			if (hasNext && !hasInitial) {
+				updates.push(
+					auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdPut({
+						...baseParams,
+						guildChannelRolePermissionRequest: {
+							accept: nextAccept,
+							deny: nextDeny
+						} as any
+					})
+				);
+				continue;
+			}
+			if (!hasNext && !hasInitial) continue;
+			if (nextAccept === initialAccept && nextDeny === initialDeny) continue;
+			if (nextAccept === 0 && nextDeny === 0) {
+				updates.push(
+					auth.api.guildRoles.guildGuildIdChannelChannelIdRolesRoleIdDelete({
+						...baseParams
+					})
 				);
 			} else {
 				updates.push(
@@ -720,58 +721,58 @@
 		}
 	}
 
-        function closeEditChannel() {
-                editChannelPermissionsLoadToken += 1;
-                editingChannel = null;
-                editChannelError = null;
-                editChannelTab = 'overview';
-                editChannelRoles = [];
-                editChannelRoleToAdd = '';
-                editChannelOverrides = {};
-                editChannelOverridesInitial = {};
-                editChannelPermissionsLoading = false;
-                editChannelPermissionsError = null;
-                editChannelSelectedOverride = null;
-                editChannelOrderedOverrideRoleIds = [];
-                editChannelInitialName = '';
-                editChannelInitialTopic = '';
-                editChannelInitialPrivate = false;
-                editChannelSaving = false;
-        }
+	function closeEditChannel() {
+		editChannelPermissionsLoadToken += 1;
+		editingChannel = null;
+		editChannelError = null;
+		editChannelTab = 'overview';
+		editChannelRoles = [];
+		editChannelRoleToAdd = '';
+		editChannelOverrides = {};
+		editChannelOverridesInitial = {};
+		editChannelPermissionsLoading = false;
+		editChannelPermissionsError = null;
+		editChannelSelectedOverride = null;
+		editChannelOrderedOverrideRoleIds = [];
+		editChannelInitialName = '';
+		editChannelInitialTopic = '';
+		editChannelInitialPrivate = false;
+		editChannelSaving = false;
+	}
 
-        async function saveEditChannel() {
-                if (!editingChannel || !$selectedGuildId || editChannelSaving) return;
-                if (!hasEditChannelChanges()) return;
-                const channelId = String((editingChannel as any)?.id ?? '');
-                if (!channelId) return;
-                editChannelSaving = true;
-                try {
-                        const shouldPatchChannel =
-                                editChannelName !== editChannelInitialName ||
-                                editChannelTopic !== editChannelInitialTopic ||
-                                editChannelPrivate !== editChannelInitialPrivate;
-                        if (shouldPatchChannel) {
-                                await auth.api.guild.guildGuildIdChannelChannelIdPatch({
-                                        guildId: BigInt($selectedGuildId) as any,
-                                        channelId: BigInt((editingChannel as any).id) as any,
-                                        guildPatchGuildChannelRequest: {
-                                                name: editChannelName,
-                                                topic: editChannelTopic,
-                                                private: editChannelPrivate
-                                        } as any
-                                });
-                        }
-                        await saveChannelPermissionOverrides($selectedGuildId, channelId);
-                        closeEditChannel();
-                        await refreshChannels();
-                } catch (e: any) {
-                        editChannelError = e?.response?.data?.message ?? e?.message ?? 'Failed to update channel';
-                } finally {
-                        if (editingChannel) {
-                                editChannelSaving = false;
-                        }
-                }
-        }
+	async function saveEditChannel() {
+		if (!editingChannel || !$selectedGuildId || editChannelSaving) return;
+		if (!hasEditChannelChanges()) return;
+		const channelId = String((editingChannel as any)?.id ?? '');
+		if (!channelId) return;
+		editChannelSaving = true;
+		try {
+			const shouldPatchChannel =
+				editChannelName !== editChannelInitialName ||
+				editChannelTopic !== editChannelInitialTopic ||
+				editChannelPrivate !== editChannelInitialPrivate;
+			if (shouldPatchChannel) {
+				await auth.api.guild.guildGuildIdChannelChannelIdPatch({
+					guildId: BigInt($selectedGuildId) as any,
+					channelId: BigInt((editingChannel as any).id) as any,
+					guildPatchGuildChannelRequest: {
+						name: editChannelName,
+						topic: editChannelTopic,
+						private: editChannelPrivate
+					} as any
+				});
+			}
+			await saveChannelPermissionOverrides($selectedGuildId, channelId);
+			closeEditChannel();
+			await refreshChannels();
+		} catch (e: any) {
+			editChannelError = e?.response?.data?.message ?? e?.message ?? 'Failed to update channel';
+		} finally {
+			if (editingChannel) {
+				editChannelSaving = false;
+			}
+		}
+	}
 
 	function openEditCategory(cat: DtoChannel) {
 		editingCategory = cat;
@@ -959,10 +960,10 @@
 									</div>
 								</div>
 							</div>
-                                                {/if}
-                                        {:else}
-                                                <div
-                                                        class="mt-2"
+						{/if}
+					{:else}
+						<div
+							class="mt-2"
 							ondragover={(e) => {
 								e.preventDefault();
 								dragOverContainer(String((sec.cat as any)?.id));
@@ -1098,287 +1099,247 @@
 	<UserPanel />
 
 	{#if editingChannel}
-		<div
-			class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-			role="dialog"
-			aria-modal="true"
-			onpointerdown={closeEditChannel}
-		>
-			<div
-				class="relative flex h-[80vh] w-full max-w-4xl overflow-hidden rounded-lg bg-[var(--bg)] shadow-xl"
-				role="document"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
+		<SettingsPanel maxWidthClass="max-w-4xl" on:close={closeEditChannel} let:close={dismissPanel}>
+			<svelte:fragment slot="sidebar">
+				<div class="text-xs font-semibold tracking-wide text-[var(--muted)] uppercase">
+					{m.channel_settings()}
+				</div>
 				<button
-					aria-label={m.close()}
-					class="absolute top-3 right-3 rounded p-1 text-xl leading-none hover:bg-[var(--panel)]"
-					onclick={closeEditChannel}
+					class={`w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] ${
+						editChannelTab === 'overview' ? 'bg-[var(--panel)] font-semibold' : ''
+					}`}
+					onclick={() => (editChannelTab = 'overview')}
 				>
-					&times;
+					{m.channel_tab_overview()}
 				</button>
-				<aside class="w-48 space-y-2 border-r border-[var(--stroke)] p-4">
-					<div class="text-xs font-semibold tracking-wide text-[var(--muted)] uppercase">
-						{m.channel_settings()}
+				<button
+					class={`w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] ${
+						editChannelTab === 'permissions' ? 'bg-[var(--panel)] font-semibold' : ''
+					}`}
+					onclick={() => (editChannelTab = 'permissions')}
+				>
+					{m.channel_tab_permissions()}
+				</button>
+			</svelte:fragment>
+
+			<h2 class="text-lg font-semibold">{m.edit_channel()}</h2>
+			{#if editChannelError}
+				<div class="rounded border border-red-500 bg-red-500/10 p-2 text-sm text-red-400">
+					{editChannelError}
+				</div>
+			{/if}
+			{#if editChannelTab === 'overview'}
+				<div class="space-y-4">
+					<div>
+						<label for="channel-name" class="mb-1 block text-sm font-medium">
+							{m.channel_name()}
+						</label>
+						<input
+							id="channel-name"
+							class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
+							placeholder={m.channel_name()}
+							bind:value={editChannelName}
+						/>
 					</div>
-					<button
-						class={`w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] ${
-							editChannelTab === 'overview' ? 'bg-[var(--panel)] font-semibold' : ''
-						}`}
-						onclick={() => (editChannelTab = 'overview')}
-					>
-						{m.channel_tab_overview()}
-					</button>
-					<button
-						class={`w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] ${
-							editChannelTab === 'permissions' ? 'bg-[var(--panel)] font-semibold' : ''
-						}`}
-						onclick={() => (editChannelTab = 'permissions')}
-					>
-						{m.channel_tab_permissions()}
-					</button>
-				</aside>
-                                <section class="flex flex-1 flex-col">
-                                        <div class="scroll-area flex-1 space-y-4 overflow-y-auto p-4">
-                                                <h2 class="text-lg font-semibold">{m.edit_channel()}</h2>
-                                                {#if editChannelError}
-                                                        <div class="rounded border border-red-500 bg-red-500/10 p-2 text-sm text-red-400">
-                                                                {editChannelError}
-							</div>
+					<div>
+						<label for="channel-topic" class="mb-1 block text-sm font-medium">
+							{m.channel_topic()}
+						</label>
+						<input
+							id="channel-topic"
+							class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
+							placeholder={m.channel_topic()}
+							bind:value={editChannelTopic}
+						/>
+					</div>
+				</div>
+			{:else if editChannelTab === 'permissions'}
+				{@const availableRoleOptions = availableRolesForOverrides()}
+				{@const overrideRoleIds = orderedOverrideRoleIds()}
+				<div class="space-y-4">
+					{#if editChannelPermissionsError}
+						<div class="rounded border border-red-500 bg-red-500/10 p-2 text-sm text-red-400">
+							{editChannelPermissionsError}
+						</div>
+					{/if}
+					<div class="rounded border border-[var(--stroke)] bg-[var(--panel)] p-4">
+						<label class="flex items-center gap-2 text-sm font-medium">
+							<input type="checkbox" bind:checked={editChannelPrivate} />
+							{m.channel_permissions_private_label()}
+						</label>
+						<p class="mt-1 text-xs text-[var(--muted)]">
+							{m.channel_permissions_private_desc()}
+						</p>
+					</div>
+					<div class="space-y-4 rounded border border-[var(--stroke)] bg-[var(--panel)] p-4">
+						<div class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+							<select
+								class="flex-1 rounded border border-[var(--stroke)] bg-[var(--bg)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
+								bind:value={editChannelRoleToAdd}
+								disabled={editChannelPermissionsLoading || availableRoleOptions.length === 0}
+							>
+								<option value="">{m.channel_permissions_select_role()}</option>
+								{#each availableRoleOptions as role}
+									{@const rid = getRoleId(role)!}
+									<option value={rid}>{roleDisplayName(role, rid)}</option>
+								{/each}
+							</select>
+							<button
+								class="rounded bg-[var(--brand)] px-3 py-2 text-[var(--bg)] disabled:opacity-50"
+								onclick={addRoleOverride}
+								disabled={!editChannelRoleToAdd}
+							>
+								{m.channel_permissions_add_role()}
+							</button>
+						</div>
+						{#if editChannelPermissionsLoading}
+							<p class="text-sm text-[var(--muted)]">{m.loading()}</p>
 						{/if}
-						{#if editChannelTab === 'overview'}
-							<div class="space-y-4">
-								<div>
-									<label for="channel-name" class="mb-1 block text-sm font-medium">
-										{m.channel_name()}
-									</label>
-									<input
-										id="channel-name"
-										class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
-										placeholder={m.channel_name()}
-										bind:value={editChannelName}
-									/>
-								</div>
-								<div>
-									<label for="channel-topic" class="mb-1 block text-sm font-medium">
-										{m.channel_topic()}
-									</label>
-									<input
-										id="channel-topic"
-										class="w-full rounded border border-[var(--stroke)] bg-[var(--panel)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
-										placeholder={m.channel_topic()}
-										bind:value={editChannelTopic}
-									/>
-								</div>
-							</div>
-						{:else if editChannelTab === 'permissions'}
-							{@const availableRoleOptions = availableRolesForOverrides()}
-							{@const overrideRoleIds = orderedOverrideRoleIds()}
-							<div class="space-y-4">
-								{#if editChannelPermissionsError}
-									<div class="rounded border border-red-500 bg-red-500/10 p-2 text-sm text-red-400">
-										{editChannelPermissionsError}
+						{#if overrideRoleIds.length > 0}
+							<div class="space-y-3">
+								<div class="space-y-2">
+									<div class="text-xs font-semibold tracking-wide text-[var(--muted)] uppercase">
+										{m.channel_permissions_role_overrides_label()}
 									</div>
-								{/if}
-								<div class="rounded border border-[var(--stroke)] bg-[var(--panel)] p-4">
-									<label class="flex items-center gap-2 text-sm font-medium">
-										<input type="checkbox" bind:checked={editChannelPrivate} />
-										{m.channel_permissions_private_label()}
-									</label>
-									<p class="mt-1 text-xs text-[var(--muted)]">
-										{m.channel_permissions_private_desc()}
-									</p>
-								</div>
-								<div class="space-y-4 rounded border border-[var(--stroke)] bg-[var(--panel)] p-4">
-									<div class="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
-										<select
-											class="flex-1 rounded border border-[var(--stroke)] bg-[var(--bg)] px-3 py-2 focus:ring-2 focus:ring-[var(--brand)] focus:outline-none"
-											bind:value={editChannelRoleToAdd}
-											disabled={editChannelPermissionsLoading || availableRoleOptions.length === 0}
-										>
-											<option value="">{m.channel_permissions_select_role()}</option>
-											{#each availableRoleOptions as role}
-												{@const rid = getRoleId(role)!}
-												<option value={rid}>{roleDisplayName(role, rid)}</option>
-											{/each}
-										</select>
-										<button
-											class="rounded bg-[var(--brand)] px-3 py-2 text-[var(--bg)] disabled:opacity-50"
-											onclick={addRoleOverride}
-											disabled={!editChannelRoleToAdd}
-										>
-											{m.channel_permissions_add_role()}
-										</button>
+									<div class="flex gap-2 overflow-x-auto pb-1">
+										{#each overrideRoleIds as roleId}
+											{@const role = editChannelRoles.find((r) => getRoleId(r) === roleId)}
+											<button
+												type="button"
+												class={`rounded-full border border-[var(--stroke)] px-3 py-1 text-sm whitespace-nowrap transition ${
+													editChannelSelectedOverride === roleId
+														? 'bg-[var(--brand)] text-[var(--bg)]'
+														: 'bg-[var(--bg)] hover:bg-[var(--panel-strong)]'
+												}`}
+												onclick={() => (editChannelSelectedOverride = roleId)}
+												aria-pressed={editChannelSelectedOverride === roleId}
+											>
+												{roleDisplayName(role, roleId)}
+											</button>
+										{/each}
 									</div>
-									{#if editChannelPermissionsLoading}
-										<p class="text-sm text-[var(--muted)]">{m.loading()}</p>
-									{/if}
-									{#if overrideRoleIds.length > 0}
-										<div class="space-y-3">
-											<div class="space-y-2">
+								</div>
+								{#if editChannelSelectedOverride && overrideRoleIds.includes(editChannelSelectedOverride)}
+									{@const selectedOverrideId = editChannelSelectedOverride as string}
+									{@const selectedRole = editChannelRoles.find(
+										(r) => getRoleId(r) === selectedOverrideId
+									)}
+									<div class="space-y-3 rounded border border-[var(--stroke)] bg-[var(--bg)] p-4">
+										<div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+											<div class="text-sm font-semibold">
+												{roleDisplayName(selectedRole, selectedOverrideId)}
+											</div>
+											<button
+												type="button"
+												class="text-xs text-red-500 hover:underline"
+												onclick={() => removeRoleOverride(selectedOverrideId)}
+											>
+												{m.channel_permissions_remove_role()}
+											</button>
+										</div>
+										{#each CHANNEL_PERMISSION_CATEGORIES as category}
+											<div>
 												<div
-													class="text-xs font-semibold tracking-wide text-[var(--muted)] uppercase"
+													class="mb-2 text-xs font-semibold tracking-wide text-[var(--muted)] uppercase"
 												>
-													{m.channel_permissions_role_overrides_label()}
+													{category.label()}
 												</div>
-												<div class="flex gap-2 overflow-x-auto pb-1">
-													{#each overrideRoleIds as roleId}
-														{@const role = editChannelRoles.find((r) => getRoleId(r) === roleId)}
-														<button
-															type="button"
-															class={`rounded-full border border-[var(--stroke)] px-3 py-1 text-sm whitespace-nowrap transition ${
-																editChannelSelectedOverride === roleId
-																	? 'bg-[var(--brand)] text-[var(--bg)]'
-																	: 'bg-[var(--bg)] hover:bg-[var(--panel-strong)]'
-															}`}
-															onclick={() => (editChannelSelectedOverride = roleId)}
-															aria-pressed={editChannelSelectedOverride === roleId}
-														>
-															{roleDisplayName(role, roleId)}
-														</button>
+												<div class="space-y-3">
+													{#each category.permissions as perm}
+														{@const state = channelPermissionState(selectedOverrideId, perm.value)}
+														<div class="rounded border border-[var(--stroke)] bg-[var(--bg)] p-3">
+															<div class="flex items-start justify-between gap-4">
+																<div>
+																	<div class="text-sm font-medium">{perm.label()}</div>
+																	<div class="text-xs text-[var(--muted)]">
+																		{perm.description()}
+																	</div>
+																</div>
+																<div
+																	class="flex overflow-hidden rounded border border-[var(--stroke)] text-xs font-semibold"
+																>
+																	<button
+																		class={`px-2 py-1 transition ${
+																			state === 'deny'
+																				? 'bg-red-500 text-white'
+																				: 'bg-transparent hover:bg-red-500/10'
+																		}`}
+																		onclick={() =>
+																			setChannelPermission(selectedOverrideId, perm.value, 'deny')}
+																		aria-label={m.permission_deny()}
+																		title={m.permission_deny()}
+																	>
+																		<X class="h-4 w-4" stroke-width={2} />
+																	</button>
+																	<button
+																		class={`px-2 py-1 transition ${
+																			state === 'inherit'
+																				? 'bg-[var(--panel)]'
+																				: 'bg-transparent hover:bg-[var(--panel)]/60'
+																		}`}
+																		onclick={() =>
+																			setChannelPermission(
+																				selectedOverrideId,
+																				perm.value,
+																				'inherit'
+																			)}
+																		aria-label={m.permission_default()}
+																		title={m.permission_default()}
+																	>
+																		<Slash class="h-4 w-4" stroke-width={2} />
+																	</button>
+																	<button
+																		class={`px-2 py-1 transition ${
+																			state === 'allow'
+																				? 'bg-green-500 text-white'
+																				: 'bg-transparent hover:bg-green-500/10'
+																		}`}
+																		onclick={() =>
+																			setChannelPermission(selectedOverrideId, perm.value, 'allow')}
+																		aria-label={m.permission_allow()}
+																		title={m.permission_allow()}
+																	>
+																		<Check class="h-4 w-4" stroke-width={2} />
+																	</button>
+																</div>
+															</div>
+														</div>
 													{/each}
 												</div>
 											</div>
-											{#if editChannelSelectedOverride && overrideRoleIds.includes(editChannelSelectedOverride)}
-												{@const selectedOverrideId = editChannelSelectedOverride as string}
-												{@const selectedRole = editChannelRoles.find(
-													(r) => getRoleId(r) === selectedOverrideId
-												)}
-												<div
-													class="space-y-3 rounded border border-[var(--stroke)] bg-[var(--bg)] p-4"
-												>
-													<div
-														class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between"
-													>
-														<div class="text-sm font-semibold">
-															{roleDisplayName(selectedRole, selectedOverrideId)}
-														</div>
-														<button
-															type="button"
-															class="text-xs text-red-500 hover:underline"
-															onclick={() => removeRoleOverride(selectedOverrideId)}
-														>
-															{m.channel_permissions_remove_role()}
-														</button>
-													</div>
-													{#each CHANNEL_PERMISSION_CATEGORIES as category}
-														<div>
-															<div
-																class="mb-2 text-xs font-semibold tracking-wide text-[var(--muted)] uppercase"
-															>
-																{category.label()}
-															</div>
-															<div class="space-y-3">
-																{#each category.permissions as perm}
-																	{@const state = channelPermissionState(
-																		selectedOverrideId,
-																		perm.value
-																	)}
-																	<div
-																		class="rounded border border-[var(--stroke)] bg-[var(--bg)] p-3"
-																	>
-																		<div class="flex items-start justify-between gap-4">
-																			<div>
-																				<div class="text-sm font-medium">{perm.label()}</div>
-																				<div class="text-xs text-[var(--muted)]">
-																					{perm.description()}
-																				</div>
-																			</div>
-																			<div
-																				class="flex overflow-hidden rounded border border-[var(--stroke)] text-xs font-semibold"
-																			>
-																				<button
-																					class={`px-2 py-1 transition ${
-																						state === 'deny'
-																							? 'bg-red-500 text-white'
-																							: 'bg-transparent hover:bg-red-500/10'
-																					}`}
-																					onclick={() =>
-																						setChannelPermission(
-																							selectedOverrideId,
-																							perm.value,
-																							'deny'
-																						)}
-																					aria-label={m.permission_deny()}
-																					title={m.permission_deny()}
-																				>
-																					<X class="h-4 w-4" stroke-width={2} />
-																				</button>
-																				<button
-																					class={`px-2 py-1 transition ${
-																						state === 'inherit'
-																							? 'bg-[var(--panel)]'
-																							: 'bg-transparent hover:bg-[var(--panel)]/60'
-																					}`}
-																					onclick={() =>
-																						setChannelPermission(
-																							selectedOverrideId,
-																							perm.value,
-																							'inherit'
-																						)}
-																					aria-label={m.permission_default()}
-																					title={m.permission_default()}
-																				>
-																					<Slash class="h-4 w-4" stroke-width={2} />
-																				</button>
-																				<button
-																					class={`px-2 py-1 transition ${
-																						state === 'allow'
-																							? 'bg-green-500 text-white'
-																							: 'bg-transparent hover:bg-green-500/10'
-																					}`}
-																					onclick={() =>
-																						setChannelPermission(
-																							selectedOverrideId,
-																							perm.value,
-																							'allow'
-																						)}
-																					aria-label={m.permission_allow()}
-																					title={m.permission_allow()}
-																				>
-																					<Check class="h-4 w-4" stroke-width={2} />
-																				</button>
-																			</div>
-																		</div>
-																	</div>
-																{/each}
-															</div>
-														</div>
-													{/each}
-												</div>
-											{:else}
-												<p class="text-sm text-[var(--muted)]">
-													{m.channel_permissions_select_override_prompt()}
-												</p>
-											{/if}
-										</div>
-									{:else if !editChannelPermissionsLoading}
-										<p class="text-sm text-[var(--muted)]">
-											{m.channel_permissions_empty()}
-										</p>
-									{/if}
-								</div>
-                                                        </div>
-                                                {/if}
-                                        </div>
-                                        <div class="flex justify-end gap-2 border-t border-[var(--stroke)] bg-[var(--panel)] p-4">
-                                                <button
-                                                        class="rounded-md border border-[var(--stroke)] px-3 py-1"
-                                                        onclick={closeEditChannel}
-                                                >
-                                                        {m.cancel()}
-                                                </button>
-                                                <button
-                                                        class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)] disabled:cursor-not-allowed disabled:opacity-50"
-                                                        onclick={saveEditChannel}
-                                                        disabled={!editChannelHasChanges || editChannelSaving}
-                                                >
-                                                        {m.save()}
-                                                </button>
-                                        </div>
-                                </section>
-                        </div>
-                </div>
-        {/if}
+										{/each}
+									</div>
+								{:else}
+									<p class="text-sm text-[var(--muted)]">
+										{m.channel_permissions_select_override_prompt()}
+									</p>
+								{/if}
+							</div>
+						{:else if !editChannelPermissionsLoading}
+							<p class="text-sm text-[var(--muted)]">
+								{m.channel_permissions_empty()}
+							</p>
+						{/if}
+					</div>
+				</div>
+			{/if}
+
+			<svelte:fragment slot="footer">
+				<div class="flex justify-end gap-2">
+					<button class="rounded-md border border-[var(--stroke)] px-3 py-1" onclick={dismissPanel}>
+						{m.cancel()}
+					</button>
+					<button
+						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)] disabled:cursor-not-allowed disabled:opacity-50"
+						onclick={saveEditChannel}
+						disabled={!editChannelHasChanges || editChannelSaving}
+					>
+						{m.save()}
+					</button>
+				</div>
+			</svelte:fragment>
+		</SettingsPanel>
+	{/if}
 
 	{#if editingCategory}
 		<div

--- a/src/lib/components/ui/SettingsPanel.svelte
+++ b/src/lib/components/ui/SettingsPanel.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+	import { createEventDispatcher } from 'svelte';
+	import { m } from '$lib/paraglide/messages.js';
+
+	export let open = true;
+	export let maxWidthClass = 'max-w-3xl';
+	export let sidebarClass = '';
+	export let contentClass = '';
+
+	const dispatch = createEventDispatcher();
+
+	const close = () => {
+		if (!open) return;
+		open = false;
+		dispatch('close');
+	};
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if (!open) return;
+		if (event.key === 'Escape') {
+			close();
+		}
+	};
+
+	const handleBackdropPointerDown = (event: PointerEvent) => {
+		if (event.target !== event.currentTarget) return;
+		close();
+	};
+</script>
+
+<svelte:window on:keydown={handleKeydown} />
+
+{#if open}
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+		role="presentation"
+		onpointerdown={handleBackdropPointerDown}
+	>
+		<div
+			class={`relative flex h-[80vh] w-full overflow-hidden rounded-lg bg-[var(--bg)] shadow-xl ${maxWidthClass}`}
+			role="dialog"
+			aria-modal="true"
+			onpointerdown={(event) => event.stopPropagation()}
+		>
+			<button
+				aria-label={m.close()}
+				class="absolute top-3 right-3 rounded p-1 text-xl leading-none hover:bg-[var(--panel)]"
+				onclick={close}
+			>
+				&times;
+			</button>
+			<aside class={`w-48 space-y-2 border-r border-[var(--stroke)] p-4 ${sidebarClass}`}>
+				<slot name="sidebar" {close} />
+			</aside>
+			<section class="flex flex-1 flex-col">
+				<div class={`scroll-area flex-1 space-y-4 overflow-y-auto p-4 ${contentClass}`}>
+					<slot {close} />
+				</div>
+				{#if $$slots.footer}
+					<footer class="border-t border-[var(--stroke)] bg-[var(--panel)] p-4">
+						<slot name="footer" {close} />
+					</footer>
+				{/if}
+			</section>
+		</div>
+	</div>
+{/if}


### PR DESCRIPTION
## Summary
- add a reusable SettingsPanel component that wraps the modal scaffold with sidebar, scrollable body, footer slot, and close handling
- refactor the user, guild, and channel settings overlays to consume the shared panel component and wire their content into sidebar/default/footer slots

## Testing
- npm run lint (fails: repository contains existing prettier formatting differences)
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d289b15834832298c52744686978d9