### PR TITLE
fix: reuse cached guild members for message colors

### DIFF
--- a/src/lib/components/app/chat/ChatPane.svelte
+++ b/src/lib/components/app/chat/ChatPane.svelte
@@ -4,7 +4,8 @@
 		channelsByGuild,
 		selectedGuildId,
 		searchOpen,
-		searchAnchor
+		searchAnchor,
+		membersByGuild
 	} from '$lib/stores/appState';
 	import { tick } from 'svelte';
 	import { m } from '$lib/paraglide/messages.js';
@@ -13,6 +14,7 @@
 	import { channelReady } from '$lib/stores/appState';
 	import { Search } from 'lucide-svelte';
 	import MemberPane from './MemberPane.svelte';
+	import { ensureGuildMembersLoaded } from '$lib/utils/guildMembers';
 	let listRef: any = null;
 
 	function currentChannel() {
@@ -29,6 +31,16 @@
 		const t = (ch?.topic ?? '').toString().trim();
 		return t;
 	}
+
+	$effect(() => {
+		const gid = $selectedGuildId ?? '';
+		if (!gid) return;
+		const map = $membersByGuild;
+		if (map && Object.prototype.hasOwnProperty.call(map, gid)) {
+			return;
+		}
+		ensureGuildMembersLoaded(gid).catch(() => {});
+	});
 </script>
 
 <div class="flex h-full min-h-0">

--- a/src/lib/utils/guildMembers.ts
+++ b/src/lib/utils/guildMembers.ts
@@ -1,0 +1,53 @@
+import { get } from 'svelte/store';
+import type { DtoMember } from '$lib/api';
+import { auth } from '$lib/stores/auth';
+import { membersByGuild } from '$lib/stores/appState';
+
+function toApiSnowflake(value: string): any {
+	try {
+		return BigInt(value) as any;
+	} catch {
+		return value as any;
+	}
+}
+
+const inflightLoads = new Map<string, Promise<DtoMember[]>>();
+
+export function ensureGuildMembersLoaded(guildId: string): Promise<DtoMember[]> {
+	const gid = String(guildId ?? '');
+	if (!gid) {
+		return Promise.resolve([]);
+	}
+
+	const cached = get(membersByGuild);
+	if (cached && Object.prototype.hasOwnProperty.call(cached, gid)) {
+		return Promise.resolve((cached[gid] ?? []) as DtoMember[]);
+	}
+
+	const existing = inflightLoads.get(gid);
+	if (existing) {
+		return existing;
+	}
+
+	const wrapped = Promise.resolve(
+		auth.api.guild.guildGuildIdMembersGet({ guildId: toApiSnowflake(gid) })
+	)
+		.then((res) => {
+			const list = ((res as any)?.data ?? res ?? []) as DtoMember[];
+			membersByGuild.update((value) => ({ ...value, [gid]: list }));
+			return list;
+		})
+		.then(
+			(list) => {
+				inflightLoads.delete(gid);
+				return list;
+			},
+			(err) => {
+				inflightLoads.delete(gid);
+				throw err;
+			}
+		);
+
+	inflightLoads.set(gid, wrapped);
+	return wrapped;
+}


### PR DESCRIPTION
## Summary
- reuse the guild member cache when resolving message author role colors
- add a shared guild member loader and hook chat pane/member pane up to it so caches populate outside the sidebar

## Testing
- npm run lint *(fails: prettier --check reports existing formatting issues across repository)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52153ee6c83229a375e3c566b26aa