### PR TITLE
fix: sync member role and override caches

### DIFF
--- a/src/lib/stores/appState.ts
+++ b/src/lib/stores/appState.ts
@@ -8,6 +8,8 @@ export const channelsByGuild = writable<Record<string, DtoChannel[]>>({});
 export const messagesByChannel = writable<Record<string, DtoMessage[]>>({});
 export const membersByGuild = writable<Record<string, DtoMember[] | undefined>>({});
 
+export const channelOverridesRefreshToken = writable(0);
+
 export const searchOpen = writable(false);
 export const searchQuery = writable('');
 export const searchAnchor = writable<{ x: number; y: number } | null>(null);


### PR DESCRIPTION
## Summary
- update the websocket guild permission sync to keep `membersByGuild` role lists current and trigger override refreshes
- add a refresh token store and wire `MemberPane` to reload channel override permissions when notified

## Testing
- `npm run lint` *(fails: Prettier reports existing style issues in unrelated files)*
- `npm run check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d53284cb948322b1738babca0001aa