### PR TITLE
fix: resolve duplicate channel role refresh import

### DIFF
--- a/src/lib/utils/guildPermissionSync.ts
+++ b/src/lib/utils/guildPermissionSync.ts
@@ -7,8 +7,7 @@ import {
         loadGuildRolesCached,
         invalidateGuildRolesCache,
         getGuildIdForRole,
-        rememberRoleGuild,
-        refreshChannelRoleIds
+        rememberRoleGuild
 } from '$lib/utils/guildRoles';
 import { refreshChannelRoleIds } from '$lib/utils/channelRoles';
 import { normalizePermissionValue } from '$lib/utils/permissions';


### PR DESCRIPTION
## Summary
- stop importing `refreshChannelRoleIds` twice in `guildPermissionSync` to avoid duplicate identifier errors
- rely on the channel role utilities module for refreshing channel role caches

## Testing
- npm run lint *(fails: existing Prettier formatting issues in unrelated files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5aafe39308322bef304e2c56292cb