### PR TITLE
fix: avoid fetching member roles for users not in guild

### DIFF
--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -547,22 +547,23 @@
 	$effect(() => {
 		const guildId = $selectedGuildId;
 		const initialRoleIds = extractAuthorRoleIds(message);
-		const authorId = toSnowflake((message as any)?.author?.id);
-		const guildMemberList = guildId ? ($membersByGuild[guildId] ?? undefined) : undefined;
-		const memberIndex = new Map<string, DtoMember>();
-		if (Array.isArray(guildMemberList)) {
-			for (const entry of guildMemberList) {
-				const id = memberUserId(entry);
-				if (id) {
-					memberIndex.set(id, entry);
-				}
-			}
-		}
-		const requestId = ++roleColorRequest;
-		primaryRoleColor = null;
+                const authorId = toSnowflake((message as any)?.author?.id);
+                const guildMemberList = guildId ? ($membersByGuild[guildId] ?? undefined) : undefined;
+                const memberIndex = new Map<string, DtoMember>();
+                if (Array.isArray(guildMemberList)) {
+                        for (const entry of guildMemberList) {
+                                const id = memberUserId(entry);
+                                if (id) {
+                                        memberIndex.set(id, entry);
+                                }
+                        }
+                }
+                const cachedMember = authorId ? memberIndex.get(authorId) ?? null : null;
+                const requestId = ++roleColorRequest;
+                primaryRoleColor = null;
 
-		if (!guildId) {
-			return;
+                if (!guildId) {
+                        return;
 		}
 
 		const activeGuildId = guildId;
@@ -570,21 +571,18 @@
 		void (async () => {
 			try {
 				let roleIds: string[] = (initialRoleIds ?? []).filter((id) => id != null && id !== '');
-				if (roleIds.length === 0 && authorId) {
-					const cachedMember = memberIndex.get(authorId);
-					if (cachedMember) {
-						const cached = collectMemberRoleIds(cachedMember, activeGuildId);
-						if (cached.length > 0) {
-							roleIds = cached;
-						}
-					}
-				}
-				if (roleIds.length === 0 && activeGuildId && authorId) {
-					const fetched = await loadMemberRoleIds(activeGuildId, authorId);
-					if (requestId !== roleColorRequest) {
-						return;
-					}
-					roleIds = Array.from(fetched);
+                                if (roleIds.length === 0 && cachedMember) {
+                                        const cached = collectMemberRoleIds(cachedMember, activeGuildId);
+                                        if (cached.length > 0) {
+                                                roleIds = cached;
+                                        }
+                                }
+                                if (roleIds.length === 0 && activeGuildId && authorId && cachedMember) {
+                                        const fetched = await loadMemberRoleIds(activeGuildId, authorId);
+                                        if (requestId !== roleColorRequest) {
+                                                return;
+                                        }
+                                        roleIds = Array.from(fetched);
 				}
 
 				const orderedRoleIds: string[] = [];


### PR DESCRIPTION
## Summary
- avoid calling the guild member roles endpoint for message authors who are not present in the cached guild member list

## Testing
- npm run lint (fails: existing Prettier violations in repository)
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b39a3f688322be6a8583f01460f6