### PR TITLE
fix: reorder message context menu items

### DIFF
--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -835,36 +835,39 @@
 		dispatch('deleted');
 	}
 
-	function openMessageMenu(e: MouseEvent) {
-		e.preventDefault();
-		e.stopPropagation();
-		const mid = String((message as any)?.id ?? '');
-		const items: ContextMenuItem[] = [];
-		if (canDeleteMessage) {
-			items.push({
-				label: m.ctx_delete_message(),
-				action: () => deleteMsg(),
-				danger: true,
-				disabled: !message?.id
-			});
-		}
-		items.push({
-			label: m.ctx_copy_message_id(),
-			action: () => copyToClipboard(mid),
-			disabled: !mid
-		});
-		if (canEditMessage) {
-			items.push({
-				label: m.ctx_edit_message(),
-				action: () => {
-					void startEditing();
-				},
-				disabled: !message?.id
-			});
-		}
-		if (items.length === 0) return;
-		contextMenu.openFromEvent(e, items);
-	}
+        function openMessageMenu(e: MouseEvent) {
+                e.preventDefault();
+                e.stopPropagation();
+                const mid = String((message as any)?.id ?? '');
+                const items: ContextMenuItem[] = [];
+                const deleteItem: ContextMenuItem | null = canDeleteMessage
+                        ? {
+                                      label: m.ctx_delete_message(),
+                                      action: () => deleteMsg(),
+                                      danger: true,
+                                      disabled: !message?.id
+                              }
+                        : null;
+                items.push({
+                        label: m.ctx_copy_message_id(),
+                        action: () => copyToClipboard(mid),
+                        disabled: !mid
+                });
+                if (canEditMessage) {
+                        items.push({
+                                label: m.ctx_edit_message(),
+                                action: () => {
+                                        void startEditing();
+                                },
+                                disabled: !message?.id
+                        });
+                }
+                if (deleteItem) {
+                        items.push(deleteItem);
+                }
+                if (items.length === 0) return;
+                contextMenu.openFromEvent(e, items);
+        }
 
 	function openUserMenu(event: MouseEvent) {
 		openUserContextMenu(


### PR DESCRIPTION
## Summary
- store the delete option separately when building the message context menu so other entries are appended first
- append the delete entry after the non-destructive items while preserving its danger and disabled state

## Testing
- npm run lint *(fails: existing Prettier formatting warnings across unrelated files)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b58d40bc832298bc306f25530c35