### PR TITLE
fix: honor channel override order

### DIFF
--- a/src/lib/utils/channelOverrides.spec.ts
+++ b/src/lib/utils/channelOverrides.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { PERMISSION_ADMINISTRATOR } from '$lib/utils/permissions';
+
+import { applyViewChannelOverrides, finalChannelAccessDecision } from './channelOverrides';
+
+const VIEW_CHANNEL = 1 << 0;
+
+describe('channel overrides', () => {
+        it('allows members with role-specific overrides despite @everyone deny', () => {
+                const guildId = '1111';
+                const allowedRoleId = '2231767118620131328';
+                const overrides = {
+                        [guildId]: { accept: 0, deny: VIEW_CHANNEL },
+                        [allowedRoleId]: { accept: VIEW_CHANNEL, deny: 0 }
+                };
+
+                const baseAllowed = false;
+
+                const allowedMember = applyViewChannelOverrides(
+                        baseAllowed,
+                        [allowedRoleId],
+                        guildId,
+                        overrides,
+                        VIEW_CHANNEL
+                );
+                const deniedMember = applyViewChannelOverrides(
+                        baseAllowed,
+                        [],
+                        guildId,
+                        overrides,
+                        VIEW_CHANNEL
+                );
+
+                const finalAllowed = finalChannelAccessDecision(
+                        allowedMember,
+                        0,
+                        PERMISSION_ADMINISTRATOR,
+                        null,
+                        null,
+                        true
+                );
+                const finalDenied = finalChannelAccessDecision(
+                        deniedMember,
+                        0,
+                        PERMISSION_ADMINISTRATOR,
+                        null,
+                        null,
+                        true
+                );
+
+                expect(finalAllowed).toBe(true);
+                expect(finalDenied).toBe(false);
+        });
+
+        it('keeps administrators visible even when channel overrides deny access', () => {
+                const guildId = 'guild';
+                const overrides = {
+                        [guildId]: { accept: 0, deny: VIEW_CHANNEL }
+                };
+
+                const basePermissions = PERMISSION_ADMINISTRATOR;
+
+                const overridden = applyViewChannelOverrides(
+                        true,
+                        [],
+                        guildId,
+                        overrides,
+                        VIEW_CHANNEL
+                );
+
+                const finalAllowed = finalChannelAccessDecision(
+                        overridden,
+                        basePermissions,
+                        PERMISSION_ADMINISTRATOR,
+                        null,
+                        null,
+                        true
+                );
+
+                expect(finalAllowed).toBe(true);
+        });
+});
+

--- a/src/lib/utils/channelOverrides.ts
+++ b/src/lib/utils/channelOverrides.ts
@@ -1,0 +1,70 @@
+export type ChannelOverride = { accept: number; deny: number };
+
+export type ChannelOverrideMap = Record<string, ChannelOverride>;
+
+function applyOverride(
+        allowed: boolean,
+        override: ChannelOverride | undefined,
+        viewPermissionBit: number
+): boolean {
+        if (!override) return allowed;
+        let result = allowed;
+        if ((override.deny & viewPermissionBit) === viewPermissionBit) {
+                result = false;
+        }
+        if ((override.accept & viewPermissionBit) === viewPermissionBit) {
+                result = true;
+        }
+        return result;
+}
+
+export function applyViewChannelOverrides(
+        initialAllowed: boolean,
+        roleIds: string[],
+        guildId: string | null,
+        overrides: ChannelOverrideMap,
+        viewPermissionBit: number
+): boolean {
+        let allowed = initialAllowed;
+        const seen = new Set<string>();
+
+        const applyForRole = (roleId: string | null | undefined) => {
+                if (!roleId) return;
+                if (seen.has(roleId)) return;
+                seen.add(roleId);
+                allowed = applyOverride(allowed, overrides[roleId], viewPermissionBit);
+        };
+
+        applyForRole(guildId);
+        for (const roleId of roleIds) {
+                applyForRole(roleId);
+        }
+
+        return allowed;
+}
+
+export function finalChannelAccessDecision(
+        baseAllowed: boolean,
+        basePermissions: number,
+        administratorBit: number,
+        guildOwnerId: string | null,
+        memberId: string | null,
+        channelIsPrivate: boolean
+): boolean {
+        let allowed = baseAllowed;
+
+        if (!allowed) {
+                if (basePermissions & administratorBit) {
+                        allowed = true;
+                } else if (guildOwnerId && memberId && guildOwnerId === memberId) {
+                        allowed = true;
+                }
+        }
+
+        if (!allowed && !channelIsPrivate) {
+                allowed = true;
+        }
+
+        return allowed;
+}
+


### PR DESCRIPTION
## Summary
- apply channel role overrides sequentially so role-specific allows can override @everyone denies while keeping existing fallbacks
- introduce a shared helper for override evaluation and reuse it inside the member pane
- cover the override behaviour with vitest tests that confirm private channel visibility for allowed roles

## Testing
- npm run test
- npm run lint *(fails: repository has existing prettier formatting differences)*
- npm run check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c2b681f48322ad0d1ea4e33e6c6a