### PR TITLE
fix: filter channel view roles

### DIFF
--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -34,6 +34,7 @@
                 invalidateChannelRoleIds
         } from '$lib/utils/guildRoles';
         import { CHANNEL_PERMISSION_CATEGORIES } from '$lib/utils/permissionDefinitions';
+        import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
         import {
                 PERMISSION_MANAGE_CHANNELS,
                 PERMISSION_MANAGE_GUILD,
@@ -164,22 +165,10 @@
 
         function inlineChannelRoleIds(channel: DtoChannel): string[] {
                 const inlineRoles = (channel as any)?.roles;
-                const seen = new Set<string>();
-                const collected: string[] = [];
                 if (!Array.isArray(inlineRoles)) {
-                        return collected;
+                        return [];
                 }
-                for (const entry of inlineRoles) {
-                        const rid =
-                                entry && typeof entry === 'object'
-                                        ? toSnowflakeString((entry as any)?.id ?? (entry as any)?.role_id ?? entry)
-                                        : toSnowflakeString(entry);
-                        if (rid && !seen.has(rid)) {
-                                seen.add(rid);
-                                collected.push(rid);
-                        }
-                }
-                return collected;
+                return filterViewableRoleIds(inlineRoles as any);
         }
 
         function rememberInlineChannelRoles(

--- a/src/lib/utils/channelRolePermissions.ts
+++ b/src/lib/utils/channelRolePermissions.ts
@@ -1,0 +1,41 @@
+import type { GuildChannelRolePermission } from '$lib/api';
+import { normalizePermissionValue, PERMISSION_VIEW_CHANNEL } from '$lib/utils/permissions';
+
+type ChannelRoleLike =
+        | GuildChannelRolePermission
+        | (Partial<GuildChannelRolePermission> & { id?: unknown; roleId?: unknown });
+
+function toSnowflakeString(value: unknown): string | null {
+        if (value == null) return null;
+        try {
+                if (typeof value === 'string') return value;
+                if (typeof value === 'bigint') return value.toString();
+                if (typeof value === 'number') return BigInt(value).toString();
+                return String(value);
+        } catch {
+                try {
+                        return String(value);
+                } catch {
+                        return null;
+                }
+        }
+}
+
+export function filterViewableRoleIds(
+        entries: Iterable<ChannelRoleLike | null | undefined> | null | undefined
+): string[] {
+        if (!entries) return [];
+        const allowed: string[] = [];
+        const seen = new Set<string>();
+        for (const entry of entries) {
+                if (!entry) continue;
+                const rawRoleId = (entry as any)?.role_id ?? (entry as any)?.roleId ?? (entry as any)?.id;
+                const roleId = toSnowflakeString(rawRoleId);
+                if (!roleId || seen.has(roleId)) continue;
+                const accept = normalizePermissionValue((entry as any)?.accept);
+                if (!(accept & PERMISSION_VIEW_CHANNEL)) continue;
+                seen.add(roleId);
+                allowed.push(roleId);
+        }
+        return allowed;
+}

--- a/src/lib/utils/channelRoles.spec.ts
+++ b/src/lib/utils/channelRoles.spec.ts
@@ -1,0 +1,54 @@
+import { get } from 'svelte/store';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('$lib/stores/auth', () => {
+        const guildRoles = {
+                guildGuildIdChannelChannelIdRolesGet: vi.fn()
+        };
+        return {
+                auth: {
+                        api: { guildRoles },
+                        guilds: { subscribe: () => () => {} },
+                        user: { subscribe: () => () => {} }
+                }
+        };
+});
+
+import { auth } from '$lib/stores/auth';
+import { channelRolesByGuild } from '$lib/stores/appState';
+import { loadChannelRoleIds, invalidateGuildRolesCache } from '$lib/utils/guildRoles';
+import { PERMISSION_VIEW_CHANNEL } from '$lib/utils/permissions';
+
+describe('channel role access filtering', () => {
+        const guildId = '1001';
+        const channelId = '2002';
+
+        beforeEach(() => {
+                invalidateGuildRolesCache();
+                channelRolesByGuild.set({});
+        });
+
+        afterEach(() => {
+                vi.restoreAllMocks();
+                invalidateGuildRolesCache();
+                channelRolesByGuild.set({});
+        });
+
+        it('prevents canAccessChannel from whitelisting roles denied VIEW_CHANNEL', async () => {
+                const allowedRoleId = '3003';
+                const deniedRoleId = '4004';
+                vi.spyOn(auth.api.guildRoles, 'guildGuildIdChannelChannelIdRolesGet').mockResolvedValue({
+                        data: [
+                                { role_id: guildId, accept: 0, deny: PERMISSION_VIEW_CHANNEL },
+                                { role_id: deniedRoleId, accept: 0, deny: PERMISSION_VIEW_CHANNEL },
+                                { role_id: allowedRoleId, accept: PERMISSION_VIEW_CHANNEL, deny: 0 }
+                        ]
+                } as any);
+
+                const roleIds = await loadChannelRoleIds(guildId, channelId);
+
+                expect(roleIds).toEqual([allowedRoleId]);
+                const store = get(channelRolesByGuild);
+                expect(store[guildId]?.[channelId]).toEqual([allowedRoleId]);
+        });
+});

--- a/src/lib/utils/channelRoles.ts
+++ b/src/lib/utils/channelRoles.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store';
 import type { DtoChannel, GuildChannelRolePermission } from '$lib/api';
 import { auth } from '$lib/stores/auth';
 import { channelRolesByGuild } from '$lib/stores/appState';
+import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
 
 function toSnowflakeString(value: unknown): string | null {
         if (value == null) return null;
@@ -88,11 +89,7 @@ async function fetchChannelRoleIds(guildId: string, channelId: string): Promise<
                 channelId: toApiSnowflake(channelId)
         });
         const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
-        const ids: string[] = [];
-        for (const entry of list) {
-                const rid = toSnowflakeString(entry?.role_id);
-                if (rid) ids.push(rid);
-        }
+        const ids = filterViewableRoleIds(list);
         setCacheEntry(guildId, channelId, ids);
         return ids;
 }

--- a/src/lib/utils/guildRoles.ts
+++ b/src/lib/utils/guildRoles.ts
@@ -2,6 +2,7 @@ import { get } from 'svelte/store';
 import type { DtoChannel, DtoRole, GuildChannelRolePermission } from '$lib/api';
 import { auth } from '$lib/stores/auth';
 import { channelRolesByGuild } from '$lib/stores/appState';
+import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
 
 const guildRolesResolved = new Map<string, DtoRole[]>();
 const guildRolesInFlight = new Map<string, Promise<DtoRole[]>>();
@@ -192,11 +193,7 @@ async function fetchChannelRoleIds(guildId: string, channelId: string): Promise<
                 channelId: toApiSnowflake(channelId)
         });
         const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
-        const ids: string[] = [];
-        for (const entry of list) {
-                const rid = toSnowflakeString(entry?.role_id);
-                if (rid) ids.push(rid);
-        }
+        const ids = filterViewableRoleIds(list);
         setChannelRoleCacheEntry(guildId, channelId, ids);
         return ids;
 }

--- a/src/lib/utils/permissions.ts
+++ b/src/lib/utils/permissions.ts
@@ -1,5 +1,6 @@
 import type { DtoGuild } from '$lib/api';
 
+export const PERMISSION_VIEW_CHANNEL = 1 << 0;
 export const PERMISSION_MANAGE_CHANNELS = 1 << 1;
 export const PERMISSION_MANAGE_ROLES = 1 << 2;
 export const PERMISSION_MANAGE_GUILD = 1 << 4;


### PR DESCRIPTION
## Summary
- ensure channel role caches only keep overrides that explicitly allow VIEW_CHANNEL
- normalize inline channel role lists using the same filtering logic for ChannelPane access checks
- add a unit test covering mixed allow/deny overrides to guard the canAccessChannel whitelist path

## Testing
- npm run test -- --reporter=basic


------
https://chatgpt.com/codex/tasks/task_e_68d5c6ed72f48322adc69383961e4509