### PR TITLE
fix: enforce private channel role allow list

### DIFF
--- a/src/lib/utils/channelRoles.ts
+++ b/src/lib/utils/channelRoles.ts
@@ -5,231 +5,251 @@ import { channelRolesByGuild } from '$lib/stores/appState';
 import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
 
 function toSnowflakeString(value: unknown): string | null {
-        if (value == null) return null;
-        try {
-                if (typeof value === 'string') return value;
-                if (typeof value === 'bigint') return value.toString();
-                if (typeof value === 'number') return BigInt(value).toString();
-                return String(value);
-        } catch {
-                try {
-                        return String(value);
-                } catch {
-                        return null;
-                }
-        }
+	if (value == null) return null;
+	try {
+		if (typeof value === 'string') return value;
+		if (typeof value === 'bigint') return value.toString();
+		if (typeof value === 'number') return BigInt(value).toString();
+		return String(value);
+	} catch {
+		try {
+			return String(value);
+		} catch {
+			return null;
+		}
+	}
 }
 
 function toApiSnowflake(value: string): any {
-        try {
-                return BigInt(value) as any;
-        } catch {
-                return value as any;
-        }
+	try {
+		return BigInt(value) as any;
+	} catch {
+		return value as any;
+	}
 }
 
 const cache = new Map<string, Map<string, string[]>>();
 const inflight = new Map<string, Map<string, Promise<string[]>>>();
 
 function setCacheEntry(guildId: string, channelId: string, roleIds: string[]) {
-        let guildCache = cache.get(guildId);
-        if (!guildCache) {
-                guildCache = new Map<string, string[]>();
-                cache.set(guildId, guildCache);
-        }
-        guildCache.set(channelId, roleIds);
-        channelRolesByGuild.update((map) => {
-                const nextGuild = { ...(map[guildId] ?? {}) };
-                nextGuild[channelId] = roleIds;
-                return { ...map, [guildId]: nextGuild };
-        });
+	let guildCache = cache.get(guildId);
+	if (!guildCache) {
+		guildCache = new Map<string, string[]>();
+		cache.set(guildId, guildCache);
+	}
+	guildCache.set(channelId, roleIds);
+	channelRolesByGuild.update((map) => {
+		const nextGuild = { ...(map[guildId] ?? {}) };
+		nextGuild[channelId] = roleIds;
+		return { ...map, [guildId]: nextGuild };
+	});
 }
 
 function deleteCacheEntry(guildId: string, channelId: string) {
-        const guildCache = cache.get(guildId);
-        if (guildCache) {
-                guildCache.delete(channelId);
-                if (guildCache.size === 0) {
-                        cache.delete(guildId);
-                }
-        }
-        channelRolesByGuild.update((map) => {
-                const existing = map[guildId];
-                if (!existing || !Object.prototype.hasOwnProperty.call(existing, channelId)) {
-                        return map;
-                }
-                const { [channelId]: _removed, ...rest } = existing;
-                return { ...map, [guildId]: rest };
-        });
+	const guildCache = cache.get(guildId);
+	if (guildCache) {
+		guildCache.delete(channelId);
+		if (guildCache.size === 0) {
+			cache.delete(guildId);
+		}
+	}
+	channelRolesByGuild.update((map) => {
+		const existing = map[guildId];
+		if (!existing || !Object.prototype.hasOwnProperty.call(existing, channelId)) {
+			return map;
+		}
+		const { [channelId]: _removed, ...rest } = existing;
+		return { ...map, [guildId]: rest };
+	});
 }
 
 export function getCachedChannelRoleIds(
-        guildId: string | number | bigint,
-        channelId: string | number | bigint
+	guildId: string | number | bigint,
+	channelId: string | number | bigint
 ): string[] | undefined {
-        const gid = toSnowflakeString(guildId);
-        const cid = toSnowflakeString(channelId);
-        if (!gid || !cid) return undefined;
-        const guildCache = cache.get(gid);
-        if (guildCache && guildCache.has(cid)) {
-                return guildCache.get(cid);
-        }
-        const store = get(channelRolesByGuild);
-        const stored = store[gid]?.[cid];
-        if (stored) {
-                setCacheEntry(gid, cid, stored);
-                return stored;
-        }
-        return undefined;
+	const gid = toSnowflakeString(guildId);
+	const cid = toSnowflakeString(channelId);
+	if (!gid || !cid) return undefined;
+	const guildCache = cache.get(gid);
+	if (guildCache && guildCache.has(cid)) {
+		return guildCache.get(cid);
+	}
+	const store = get(channelRolesByGuild);
+	const stored = store[gid]?.[cid];
+	if (stored) {
+		setCacheEntry(gid, cid, stored);
+		return stored;
+	}
+	return undefined;
+}
+
+export function channelAllowListedRoleIds(
+	guildId: string | number | bigint | null | undefined,
+	channel: Pick<DtoChannel, 'id' | 'roles'> | null | undefined,
+	snapshot?: Record<string, Record<string, string[]>>
+): string[] {
+	const gid = toSnowflakeString(guildId ?? (channel as any)?.guild_id);
+	const cid = toSnowflakeString((channel as any)?.id);
+	if (!gid || !cid) return [];
+	const store = snapshot ?? get(channelRolesByGuild);
+	const stored = store?.[gid]?.[cid];
+	if (Array.isArray(stored)) {
+		return stored;
+	}
+	const inlineRoles = (channel as any)?.roles;
+	if (!Array.isArray(inlineRoles)) {
+		return [];
+	}
+	return filterViewableRoleIds(inlineRoles as any);
 }
 
 async function fetchChannelRoleIds(guildId: string, channelId: string): Promise<string[]> {
-        const response = await auth.api.guildRoles.guildGuildIdChannelChannelIdRolesGet({
-                guildId: toApiSnowflake(guildId),
-                channelId: toApiSnowflake(channelId)
-        });
-        const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
-        const ids = filterViewableRoleIds(list);
-        setCacheEntry(guildId, channelId, ids);
-        return ids;
+	const response = await auth.api.guildRoles.guildGuildIdChannelChannelIdRolesGet({
+		guildId: toApiSnowflake(guildId),
+		channelId: toApiSnowflake(channelId)
+	});
+	const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
+	const ids = filterViewableRoleIds(list);
+	setCacheEntry(guildId, channelId, ids);
+	return ids;
 }
 
 export async function loadChannelRoleIds(
-        guildId: string | number | bigint,
-        channelId: string | number | bigint
+	guildId: string | number | bigint,
+	channelId: string | number | bigint
 ): Promise<string[]> {
-        const gid = toSnowflakeString(guildId);
-        const cid = toSnowflakeString(channelId);
-        if (!gid || !cid) return [];
-        const cached = getCachedChannelRoleIds(gid, cid);
-        if (cached) return cached;
-        let guildInflight = inflight.get(gid);
-        if (!guildInflight) {
-            guildInflight = new Map<string, Promise<string[]>>();
-            inflight.set(gid, guildInflight);
-        }
-        const existing = guildInflight.get(cid);
-        if (existing) return existing;
-        const pending = fetchChannelRoleIds(gid, cid)
-                .catch((err) => {
-                        deleteCacheEntry(gid, cid);
-                        throw err;
-                })
-                .finally(() => {
-                        const current = inflight.get(gid);
-                        current?.delete(cid);
-                        if (current && current.size === 0) {
-                                inflight.delete(gid);
-                        }
-                });
-        guildInflight.set(cid, pending);
-        return pending;
+	const gid = toSnowflakeString(guildId);
+	const cid = toSnowflakeString(channelId);
+	if (!gid || !cid) return [];
+	const cached = getCachedChannelRoleIds(gid, cid);
+	if (cached) return cached;
+	let guildInflight = inflight.get(gid);
+	if (!guildInflight) {
+		guildInflight = new Map<string, Promise<string[]>>();
+		inflight.set(gid, guildInflight);
+	}
+	const existing = guildInflight.get(cid);
+	if (existing) return existing;
+	const pending = fetchChannelRoleIds(gid, cid)
+		.catch((err) => {
+			deleteCacheEntry(gid, cid);
+			throw err;
+		})
+		.finally(() => {
+			const current = inflight.get(gid);
+			current?.delete(cid);
+			if (current && current.size === 0) {
+				inflight.delete(gid);
+			}
+		});
+	guildInflight.set(cid, pending);
+	return pending;
 }
 
 export async function refreshChannelRoleIds(
-        guildId: string | number | bigint,
-        channelId: string | number | bigint
+	guildId: string | number | bigint,
+	channelId: string | number | bigint
 ): Promise<string[]> {
-        const gid = toSnowflakeString(guildId);
-        const cid = toSnowflakeString(channelId);
-        if (!gid || !cid) return [];
-        deleteCacheEntry(gid, cid);
-        return loadChannelRoleIds(gid, cid);
+	const gid = toSnowflakeString(guildId);
+	const cid = toSnowflakeString(channelId);
+	if (!gid || !cid) return [];
+	deleteCacheEntry(gid, cid);
+	return loadChannelRoleIds(gid, cid);
 }
 
 export function invalidateChannelRoleIds(
-        guildId: string | number | bigint,
-        channelId?: string | number | bigint
+	guildId: string | number | bigint,
+	channelId?: string | number | bigint
 ) {
-        const gid = toSnowflakeString(guildId);
-        if (!gid) return;
-        if (channelId == null) {
-                cache.delete(gid);
-                inflight.delete(gid);
-                channelRolesByGuild.update((map) => {
-                        if (!Object.prototype.hasOwnProperty.call(map, gid)) return map;
-                        const { [gid]: _removed, ...rest } = map;
-                        return rest;
-                });
-                return;
-        }
-        const cid = toSnowflakeString(channelId);
-        if (!cid) return;
-        deleteCacheEntry(gid, cid);
-        const guildInflight = inflight.get(gid);
-        guildInflight?.delete(cid);
-        if (guildInflight && guildInflight.size === 0) {
-                inflight.delete(gid);
-        }
+	const gid = toSnowflakeString(guildId);
+	if (!gid) return;
+	if (channelId == null) {
+		cache.delete(gid);
+		inflight.delete(gid);
+		channelRolesByGuild.update((map) => {
+			if (!Object.prototype.hasOwnProperty.call(map, gid)) return map;
+			const { [gid]: _removed, ...rest } = map;
+			return rest;
+		});
+		return;
+	}
+	const cid = toSnowflakeString(channelId);
+	if (!cid) return;
+	deleteCacheEntry(gid, cid);
+	const guildInflight = inflight.get(gid);
+	guildInflight?.delete(cid);
+	if (guildInflight && guildInflight.size === 0) {
+		inflight.delete(gid);
+	}
 }
 
 export function pruneChannelRoleCache(
-        guildId: string | number | bigint,
-        channels: Iterable<DtoChannel | string | number | bigint>
+	guildId: string | number | bigint,
+	channels: Iterable<DtoChannel | string | number | bigint>
 ) {
-        const gid = toSnowflakeString(guildId);
-        if (!gid) return;
-        const keep = new Set<string>();
-        for (const entry of channels) {
-                const id =
-                        typeof entry === 'object' && entry !== null
-                                ? toSnowflakeString((entry as any)?.id ?? (entry as any)?.channel_id)
-                                : toSnowflakeString(entry);
-                if (id) keep.add(id);
-        }
-        if (!keep.size) {
-                invalidateChannelRoleIds(gid);
-                return;
-        }
-        const guildCache = cache.get(gid);
-        if (guildCache) {
-                for (const key of Array.from(guildCache.keys())) {
-                        if (!keep.has(key)) {
-                                guildCache.delete(key);
-                        }
-                }
-                if (guildCache.size === 0) {
-                        cache.delete(gid);
-                }
-        }
-        channelRolesByGuild.update((map) => {
-                const existing = map[gid];
-                if (!existing) return map;
-                const next: Record<string, string[]> = {};
-                for (const [key, value] of Object.entries(existing)) {
-                        if (keep.has(key)) {
-                                next[key] = value;
-                        }
-                }
-                return { ...map, [gid]: next };
-        });
+	const gid = toSnowflakeString(guildId);
+	if (!gid) return;
+	const keep = new Set<string>();
+	for (const entry of channels) {
+		const id =
+			typeof entry === 'object' && entry !== null
+				? toSnowflakeString((entry as any)?.id ?? (entry as any)?.channel_id)
+				: toSnowflakeString(entry);
+		if (id) keep.add(id);
+	}
+	if (!keep.size) {
+		invalidateChannelRoleIds(gid);
+		return;
+	}
+	const guildCache = cache.get(gid);
+	if (guildCache) {
+		for (const key of Array.from(guildCache.keys())) {
+			if (!keep.has(key)) {
+				guildCache.delete(key);
+			}
+		}
+		if (guildCache.size === 0) {
+			cache.delete(gid);
+		}
+	}
+	channelRolesByGuild.update((map) => {
+		const existing = map[gid];
+		if (!existing) return map;
+		const next: Record<string, string[]> = {};
+		for (const [key, value] of Object.entries(existing)) {
+			if (keep.has(key)) {
+				next[key] = value;
+			}
+		}
+		return { ...map, [gid]: next };
+	});
 }
 
 export async function primeGuildChannelRoles(
-        guildId: string | number | bigint,
-        channels: Iterable<DtoChannel>
+	guildId: string | number | bigint,
+	channels: Iterable<DtoChannel>
 ): Promise<void> {
-        const gid = toSnowflakeString(guildId);
-        if (!gid) return;
-        const tasks: Promise<unknown>[] = [];
-        for (const channel of channels) {
-                const channelId = toSnowflakeString((channel as any)?.id);
-                if (!channelId) continue;
-                const type = (channel as any)?.type ?? 0;
-                if (type === 2) continue;
-                const isPrivate = Boolean((channel as any)?.private);
-                if (!isPrivate) {
-                        invalidateChannelRoleIds(gid, channelId);
-                        continue;
-                }
-                if (getCachedChannelRoleIds(gid, channelId) !== undefined) continue;
-                tasks.push(
-                        loadChannelRoleIds(gid, channelId).catch(() => {
-                                /* ignore individual failures */
-                        })
-                );
-        }
-        if (tasks.length) {
-                await Promise.all(tasks);
-        }
+	const gid = toSnowflakeString(guildId);
+	if (!gid) return;
+	const tasks: Promise<unknown>[] = [];
+	for (const channel of channels) {
+		const channelId = toSnowflakeString((channel as any)?.id);
+		if (!channelId) continue;
+		const type = (channel as any)?.type ?? 0;
+		if (type === 2) continue;
+		const isPrivate = Boolean((channel as any)?.private);
+		if (!isPrivate) {
+			invalidateChannelRoleIds(gid, channelId);
+			continue;
+		}
+		if (getCachedChannelRoleIds(gid, channelId) !== undefined) continue;
+		tasks.push(
+			loadChannelRoleIds(gid, channelId).catch(() => {
+				/* ignore individual failures */
+			})
+		);
+	}
+	if (tasks.length) {
+		await Promise.all(tasks);
+	}
 }

--- a/src/lib/utils/memberChannelAccess.spec.ts
+++ b/src/lib/utils/memberChannelAccess.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { memberHasChannelAccess } from '$lib/utils/memberChannelAccess';
+import { PERMISSION_VIEW_CHANNEL, PERMISSION_ADMINISTRATOR } from '$lib/utils/permissions';
+
+describe('memberHasChannelAccess', () => {
+	const guildId = '1001';
+	const baseChannel = { private: true } as const;
+	const baseGuild = { owner: '9999' } as const;
+
+	it('denies members without allow-listed roles in a private channel', () => {
+		const member = { user: { id: '101' } } as any;
+		const roleIds = ['2002', guildId];
+		const result = memberHasChannelAccess({
+			member,
+			channel: baseChannel,
+			guild: baseGuild,
+			guildId,
+			roleIds,
+			basePermissions: PERMISSION_VIEW_CHANNEL,
+			channelOverrides: {},
+			allowListedRoleIds: ['3003'],
+			viewPermissionBit: PERMISSION_VIEW_CHANNEL
+		});
+
+		expect(result).toBe(false);
+	});
+
+	it('allows members with an allow-listed role in a private channel', () => {
+		const member = { user: { id: '102' } } as any;
+		const roleIds = ['3003', guildId];
+		const result = memberHasChannelAccess({
+			member,
+			channel: baseChannel,
+			guild: baseGuild,
+			guildId,
+			roleIds,
+			basePermissions: PERMISSION_VIEW_CHANNEL,
+			channelOverrides: {},
+			allowListedRoleIds: ['3003'],
+			viewPermissionBit: PERMISSION_VIEW_CHANNEL
+		});
+
+		expect(result).toBe(true);
+	});
+
+	it('allows administrators even without allow-listed roles', () => {
+		const member = { user: { id: '103' } } as any;
+		const roleIds = ['4004', guildId];
+		const result = memberHasChannelAccess({
+			member,
+			channel: baseChannel,
+			guild: baseGuild,
+			guildId,
+			roleIds,
+			basePermissions: PERMISSION_ADMINISTRATOR,
+			channelOverrides: {},
+			allowListedRoleIds: ['3003'],
+			viewPermissionBit: PERMISSION_VIEW_CHANNEL
+		});
+
+		expect(result).toBe(true);
+	});
+});

--- a/src/lib/utils/memberChannelAccess.ts
+++ b/src/lib/utils/memberChannelAccess.ts
@@ -1,0 +1,91 @@
+import type { DtoMember } from '$lib/api';
+import type { ChannelOverrideMap } from '$lib/utils/channelOverrides';
+import { applyViewChannelOverrides, finalChannelAccessDecision } from '$lib/utils/channelOverrides';
+import { PERMISSION_ADMINISTRATOR } from '$lib/utils/permissions';
+
+function toSnowflakeString(value: unknown): string | null {
+	if (value == null) return null;
+	try {
+		if (typeof value === 'string') return value;
+		if (typeof value === 'bigint') return value.toString();
+		if (typeof value === 'number') return BigInt(value).toString();
+		return String(value);
+	} catch {
+		try {
+			return String(value);
+		} catch {
+			return null;
+		}
+	}
+}
+
+export type MemberChannelAccessParams = {
+	member: DtoMember | null | undefined;
+	channel: any;
+	guild: any;
+	guildId: string | null;
+	roleIds: string[];
+	basePermissions: number;
+	channelOverrides: ChannelOverrideMap;
+	allowListedRoleIds: Iterable<string> | null | undefined;
+	viewPermissionBit: number;
+};
+
+export function memberHasChannelAccess({
+	member,
+	channel,
+	guild,
+	guildId,
+	roleIds,
+	basePermissions,
+	channelOverrides,
+	allowListedRoleIds,
+	viewPermissionBit
+}: MemberChannelAccessParams): boolean {
+	if (!member || !channel) return false;
+
+	const ownerId = toSnowflakeString((guild as any)?.owner);
+	const memberId = toSnowflakeString((member as any)?.user?.id);
+	const isAdmin = Boolean(basePermissions & PERMISSION_ADMINISTRATOR);
+	const isOwner = Boolean(ownerId && memberId && ownerId === memberId);
+	const channelIsPrivate = Boolean((channel as any)?.private);
+
+	if (channelIsPrivate) {
+		const allowList = Array.from(allowListedRoleIds ?? []);
+		const allowSet = new Set(allowList);
+		if (!allowSet.size) {
+			if (!isAdmin && !isOwner) {
+				return false;
+			}
+		} else {
+			let intersects = false;
+			for (const roleId of roleIds) {
+				if (allowSet.has(roleId)) {
+					intersects = true;
+					break;
+				}
+			}
+			if (!intersects && !isAdmin && !isOwner) {
+				return false;
+			}
+		}
+	}
+
+	let allowed = Boolean(basePermissions & viewPermissionBit) || isAdmin;
+	allowed = applyViewChannelOverrides(
+		allowed,
+		roleIds,
+		guildId,
+		channelOverrides,
+		viewPermissionBit
+	);
+
+	return finalChannelAccessDecision(
+		allowed,
+		basePermissions,
+		PERMISSION_ADMINISTRATOR,
+		ownerId,
+		memberId,
+		channelIsPrivate
+	);
+}


### PR DESCRIPTION
## Summary
- add a shared helper to resolve allow-listed channel role ids from cached or inline data
- enforce the allow-list when calculating private channel access in the member pane
- cover the new private channel filtering logic with dedicated member access unit tests

## Testing
- npm run lint *(fails: repository contains existing Prettier formatting issues in unrelated files)*
- npm run check
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5c8bd2bc483228029b622f044c887