### PR TITLE
fix: allow default view access for channel roles

### DIFF
--- a/src/lib/utils/channelRolePermissions.ts
+++ b/src/lib/utils/channelRolePermissions.ts
@@ -44,9 +44,17 @@ export function filterViewableRoleIds(
                 }
                 const roleId = toSnowflakeString(roleSource);
                 if (!roleId || seen.has(roleId)) continue;
+                const rawAccept = (entry as any)?.accept;
                 if (accept == null) {
-                        accept = normalizePermissionValue((entry as any)?.accept);
+                        accept =
+                                rawAccept == null
+                                        ? PERMISSION_VIEW_CHANNEL
+                                        : normalizePermissionValue(rawAccept);
+                } else if (rawAccept != null) {
+                        accept = normalizePermissionValue(rawAccept);
                 }
+                const deny = normalizePermissionValue((entry as any)?.deny);
+                if (deny & PERMISSION_VIEW_CHANNEL) continue;
                 if (!(accept & PERMISSION_VIEW_CHANNEL)) continue;
                 seen.add(roleId);
                 allowed.push(roleId);

--- a/src/lib/utils/channelRoles.spec.ts
+++ b/src/lib/utils/channelRoles.spec.ts
@@ -62,9 +62,21 @@ describe('channel role access filtering', () => {
                         { role_id: '8008', accept: PERMISSION_VIEW_CHANNEL },
                         { roleId: '9009', accept: 0 },
                         { id: '10010', accept: PERMISSION_VIEW_CHANNEL }
-                ]);
+                ] as any);
 
                 expect(result).toEqual(['5005', '6006', '7007', '8008', '10010']);
+        });
+
+        it('defaults missing accept masks to allow while respecting explicit denies', () => {
+                const result = filterViewableRoleIds([
+                        { role_id: '13013' },
+                        { role_id: '14014', accept: null },
+                        { role_id: '15015', accept: undefined },
+                        { role_id: '16016', deny: PERMISSION_VIEW_CHANNEL },
+                        { role_id: '17017', accept: 0 }
+                ] as any);
+
+                expect(result).toEqual(['13013', '14014', '15015']);
         });
 
         it('falls back to inline channel role allow-lists when API data is unavailable', () => {


### PR DESCRIPTION
## Summary
- default missing channel role accept masks to grant view access while still ignoring explicit denies
- add a unit test covering roles without accept values to ensure they stay in the allow list

## Testing
- npm run lint *(fails: repository has existing Prettier formatting issues)*
- npm run check
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5e09316cc8322a6392be93f569eff