### PR TITLE
fix: include roleId when collecting member roles

### DIFF
--- a/src/lib/utils/currentUserRoleIds.spec.ts
+++ b/src/lib/utils/currentUserRoleIds.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveCurrentUserRoleIds } from '$lib/utils/currentUserRoleIds';
+import { collectMemberRoleIds, resolveCurrentUserRoleIds } from '$lib/utils/currentUserRoleIds';
 
 describe('resolveCurrentUserRoleIds', () => {
 	const guildId = '1234';
@@ -39,11 +39,11 @@ describe('resolveCurrentUserRoleIds', () => {
 		expect(Array.from(result).sort()).toEqual(['1111', '1234', '2222', '3333']);
 	});
 
-	it('normalizes mixed identifier types and removes duplicates', () => {
-		const fallbackRoles = new Set<unknown>(['4444', 5555, 6666n]);
-		const members = [
-			{
-				user: { id: currentUserId },
+        it('normalizes mixed identifier types and removes duplicates', () => {
+                const fallbackRoles = new Set<unknown>(['4444', 5555, 6666n]);
+                const members = [
+                        {
+                                user: { id: currentUserId },
 				roles: ['4444', { id: 5555 }, { role_id: 7777n }]
 			}
 		] as any;
@@ -55,6 +55,22 @@ describe('resolveCurrentUserRoleIds', () => {
 			fallbackRoleIds: fallbackRoles
 		});
 
-		expect(Array.from(result).sort()).toEqual(['1234', '4444', '5555', '6666', '7777']);
-	});
+                expect(Array.from(result).sort()).toEqual(['1234', '4444', '5555', '6666', '7777']);
+        });
+
+        it('collectMemberRoleIds handles roleId properties on role objects', () => {
+                const member = {
+                        user: { id: currentUserId },
+                        roles: [
+                                { roleId: '8888' },
+                                { id: '9999' },
+                                { role_id: '7777' },
+                                '6666'
+                        ]
+                } as any;
+
+                const result = collectMemberRoleIds(member);
+
+                expect(result.sort()).toEqual(['6666', '7777', '8888', '9999']);
+        });
 });

--- a/src/lib/utils/currentUserRoleIds.ts
+++ b/src/lib/utils/currentUserRoleIds.ts
@@ -33,10 +33,15 @@ export function collectMemberRoleIds(member: DtoMember | undefined): string[] {
 	const seen = new Set<string>();
 	const result: string[] = [];
 	for (const entry of list) {
-		const id =
-			entry && typeof entry === 'object'
-				? toSnowflakeString((entry as any)?.id ?? (entry as any)?.role_id ?? entry)
-				: toSnowflakeString(entry);
+                const id =
+                        entry && typeof entry === 'object'
+                                ? toSnowflakeString(
+                                          (entry as any)?.id ??
+                                                  (entry as any)?.role_id ??
+                                                  (entry as any)?.roleId ??
+                                                  entry
+                                      )
+                                : toSnowflakeString(entry);
 		if (id && !seen.has(id)) {
 			seen.add(id);
 			result.push(id);


### PR DESCRIPTION
## Summary
- ensure collectMemberRoleIds handles roleId fields in role objects in addition to id and role_id
- add a unit test covering roleId inputs and import the helper into the existing spec suite

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5e78463bc83228d2d78bb341e5987