### PR TITLE
fix: normalize member role objects in chat views

### DIFF
--- a/src/lib/components/app/chat/MemberPane.svelte
+++ b/src/lib/components/app/chat/MemberPane.svelte
@@ -113,22 +113,35 @@
 		return map;
 	}
 
-	function collectMemberRoleIds(
-		member: DtoMember | null | undefined,
-		guildId: string | null
-	): string[] {
-		const ids = new Set<string>();
-		if (member && Array.isArray((member as any)?.roles)) {
-			for (const raw of (member as any)?.roles ?? []) {
-				const id = toSnowflakeString(raw);
-				if (id) ids.add(id);
-			}
-		}
-		if (guildId) {
-			ids.add(guildId);
-		}
-		return Array.from(ids);
-	}
+        function collectMemberRoleIds(
+                member: DtoMember | null | undefined,
+                guildId: string | null
+        ): string[] {
+                const ids = new Set<string>();
+                const roles = (member as any)?.roles;
+                const list = Array.isArray(roles) ? roles : [];
+
+                for (const entry of list) {
+                        const id =
+                                entry && typeof entry === 'object'
+                                        ? toSnowflakeString(
+                                                  (entry as any)?.id ??
+                                                          (entry as any)?.role_id ??
+                                                          (entry as any)?.roleId ??
+                                                          entry
+                                          )
+                                        : toSnowflakeString(entry);
+                        if (id) {
+                                ids.add(id);
+                        }
+                }
+
+                if (guildId) {
+                        ids.add(guildId);
+                }
+
+                return Array.from(ids);
+        }
 
 	function resolveMemberRoleColor(
 		member: DtoMember | null | undefined,

--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -104,22 +104,35 @@
 		);
 	}
 
-	function collectMemberRoleIds(
-		member: DtoMember | null | undefined,
-		guildId: string | null
-	): string[] {
-		const ids = new Set<string>();
-		if (member && Array.isArray((member as any)?.roles)) {
-			for (const raw of (member as any)?.roles ?? []) {
-				const id = toSnowflake(raw);
-				if (id) ids.add(id);
-			}
-		}
-		if (guildId) {
-			ids.add(guildId);
-		}
-		return Array.from(ids);
-	}
+        function collectMemberRoleIds(
+                member: DtoMember | null | undefined,
+                guildId: string | null
+        ): string[] {
+                const ids = new Set<string>();
+                const roles = (member as any)?.roles;
+                const list = Array.isArray(roles) ? roles : [];
+
+                for (const entry of list) {
+                        const id =
+                                entry && typeof entry === 'object'
+                                        ? toSnowflake(
+                                                  (entry as any)?.id ??
+                                                          (entry as any)?.role_id ??
+                                                          (entry as any)?.roleId ??
+                                                          entry
+                                          )
+                                        : toSnowflake(entry);
+                        if (id) {
+                                ids.add(id);
+                        }
+                }
+
+                if (guildId) {
+                        ids.add(guildId);
+                }
+
+                return Array.from(ids);
+        }
 
 	function extractAuthorRoleIds(msg: DtoMessage | null | undefined): string[] {
 		if (!msg) return [];

--- a/src/lib/utils/memberChannelAccess.spec.ts
+++ b/src/lib/utils/memberChannelAccess.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { memberHasChannelAccess } from '$lib/utils/memberChannelAccess';
+import { collectMemberRoleIds } from '$lib/utils/currentUserRoleIds';
 import { PERMISSION_VIEW_CHANNEL, PERMISSION_ADMINISTRATOR } from '$lib/utils/permissions';
 
 describe('memberHasChannelAccess', () => {
@@ -43,11 +44,11 @@ describe('memberHasChannelAccess', () => {
 		expect(result).toBe(true);
 	});
 
-	it('allows administrators even without allow-listed roles', () => {
-		const member = { user: { id: '103' } } as any;
-		const roleIds = ['4004', guildId];
-		const result = memberHasChannelAccess({
-			member,
+        it('allows administrators even without allow-listed roles', () => {
+                const member = { user: { id: '103' } } as any;
+                const roleIds = ['4004', guildId];
+                const result = memberHasChannelAccess({
+                        member,
 			channel: baseChannel,
 			guild: baseGuild,
 			guildId,
@@ -58,6 +59,28 @@ describe('memberHasChannelAccess', () => {
 			viewPermissionBit: PERMISSION_VIEW_CHANNEL
 		});
 
-		expect(result).toBe(true);
-	});
+        expect(result).toBe(true);
+        });
+
+        it('allows members whose roles are provided as objects with roleId fields', () => {
+                const member = {
+                        user: { id: '104' },
+                        roles: [{ roleId: '5005' }]
+                } as any;
+                const roleIds = [...collectMemberRoleIds(member), guildId];
+
+                const result = memberHasChannelAccess({
+                        member,
+                        channel: baseChannel,
+                        guild: baseGuild,
+                        guildId,
+                        roleIds,
+                        basePermissions: PERMISSION_VIEW_CHANNEL,
+                        channelOverrides: {},
+                        allowListedRoleIds: ['5005'],
+                        viewPermissionBit: PERMISSION_VIEW_CHANNEL
+                });
+
+                expect(result).toBe(true);
+        });
 });


### PR DESCRIPTION
## Summary
- normalize member role collection in chat panes to handle role objects with `id`, `role_id`, or `roleId`
- ensure message item role aggregation prefers explicit identifiers before falling back to string coercion
- extend channel access tests to cover members whose roles are expressed as objects

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5eae40efc8322986c358aa3d297ea