### PR TITLE
fix: normalize channel role identifiers

### DIFF
--- a/src/lib/utils/channelRolePermissions.ts
+++ b/src/lib/utils/channelRolePermissions.ts
@@ -29,7 +29,11 @@ export function filterViewableRoleIds(
         const seen = new Set<string>();
         for (const entry of entries) {
                 if (!entry) continue;
-                const rawRoleId = (entry as any)?.role_id ?? (entry as any)?.roleId ?? (entry as any)?.id;
+                const rawRoleId =
+                        (entry as any)?.role?.id ??
+                        (entry as any)?.role_id ??
+                        (entry as any)?.roleId ??
+                        (entry as any)?.id;
                 let roleSource: unknown = rawRoleId;
                 let accept: number | undefined;
                 if (roleSource == null) {

--- a/src/lib/utils/channelRoles.spec.ts
+++ b/src/lib/utils/channelRoles.spec.ts
@@ -59,6 +59,7 @@ describe('channel role access filtering', () => {
                         '5005',
                         6006,
                         7007n,
+                        { role: { id: '5005' }, accept: PERMISSION_VIEW_CHANNEL },
                         { role_id: '8008', accept: PERMISSION_VIEW_CHANNEL },
                         { roleId: '9009', accept: 0 },
                         { id: '10010', accept: PERMISSION_VIEW_CHANNEL }
@@ -83,11 +84,16 @@ describe('channel role access filtering', () => {
                 const inlineChannel = {
                         id: channelId,
                         guild_id: guildId,
-                        roles: ['11011', { role_id: '12012', accept: PERMISSION_VIEW_CHANNEL }, 13013n]
+                        roles: [
+                                '11011',
+                                { role: { id: '12012' }, accept: PERMISSION_VIEW_CHANNEL },
+                                { role_id: '13013', accept: PERMISSION_VIEW_CHANNEL },
+                                14014n
+                        ]
                 } as any;
 
                 const result = channelAllowListedRoleIds(guildId, inlineChannel);
 
-                expect(result).toEqual(['11011', '12012', '13013']);
+                expect(result).toEqual(['11011', '12012', '13013', '14014']);
         });
 });


### PR DESCRIPTION
## Summary
- normalize `filterViewableRoleIds` to read nested `role.id` properties before coercion
- add regression coverage for nested role objects and inline channel allow-lists

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5f124e61c8322a330df6950b32a14