### PR TITLE
fix: include nested role ids when collecting member roles

### DIFF
--- a/src/lib/utils/currentUserRoleIds.spec.ts
+++ b/src/lib/utils/currentUserRoleIds.spec.ts
@@ -73,4 +73,15 @@ describe('resolveCurrentUserRoleIds', () => {
 
                 expect(result.sort()).toEqual(['6666', '7777', '8888', '9999']);
         });
+
+        it('collectMemberRoleIds handles nested role objects', () => {
+                const member = {
+                        user: { id: currentUserId },
+                        roles: [{ role: { id: '5005' } }]
+                } as any;
+
+                const result = collectMemberRoleIds(member);
+
+                expect(result).toEqual(['5005']);
+        });
 });

--- a/src/lib/utils/currentUserRoleIds.ts
+++ b/src/lib/utils/currentUserRoleIds.ts
@@ -39,6 +39,7 @@ export function collectMemberRoleIds(member: DtoMember | undefined): string[] {
                                           (entry as any)?.id ??
                                                   (entry as any)?.role_id ??
                                                   (entry as any)?.roleId ??
+                                                  (entry as any)?.role?.id ??
                                                   entry
                                       )
                                 : toSnowflakeString(entry);


### PR DESCRIPTION
## Summary
- include nested `role.id` values when normalizing member role identifiers
- add a unit test covering nested role objects in `collectMemberRoleIds`

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d5f1a9ec4c8322be97fa21d4d3c1e2