### PR TITLE
fix: normalize member role aggregation in member pane

### DIFF
--- a/src/lib/utils/memberChannelAccess.spec.ts
+++ b/src/lib/utils/memberChannelAccess.spec.ts
@@ -83,4 +83,26 @@ describe('memberHasChannelAccess', () => {
 
                 expect(result).toBe(true);
         });
+
+        it('allows members whose roles provide nested role.id fields', () => {
+                const member = {
+                        user: { id: '105' },
+                        roles: [{ role: { id: '6006' } }]
+                } as any;
+                const roleIds = [...collectMemberRoleIds(member), guildId];
+
+                const result = memberHasChannelAccess({
+                        member,
+                        channel: baseChannel,
+                        guild: baseGuild,
+                        guildId,
+                        roleIds,
+                        basePermissions: PERMISSION_VIEW_CHANNEL,
+                        channelOverrides: {},
+                        allowListedRoleIds: ['6006'],
+                        viewPermissionBit: PERMISSION_VIEW_CHANNEL
+                });
+
+                expect(result).toBe(true);
+        });
 });


### PR DESCRIPTION
## Summary
- reuse the shared member role normalization helper in the MemberPane to ensure channel logic sees consistent IDs
- extend the member channel access test suite to cover roles delivered via nested role.id objects

## Testing
- npm run test -- memberChannelAccess

------
https://chatgpt.com/codex/tasks/task_e_68d662d373ec8322a48a8604661cde77