### PR TITLE
fix: prioritize nested member role identifiers

### DIFF
--- a/src/lib/utils/currentUserRoleIds.spec.ts
+++ b/src/lib/utils/currentUserRoleIds.spec.ts
@@ -77,7 +77,7 @@ describe('resolveCurrentUserRoleIds', () => {
         it('collectMemberRoleIds picks nested role identifiers before raw entries', () => {
                 const member = {
                         user: { id: currentUserId },
-                        roles: [{ role: { id: '5005' } }]
+                        roles: [{ role: { id: '5005' } }, '5005']
                 } as any;
 
                 const result = collectMemberRoleIds(member);

--- a/src/lib/utils/currentUserRoleIds.ts
+++ b/src/lib/utils/currentUserRoleIds.ts
@@ -37,7 +37,7 @@ export function collectMemberRoleIds(member: DtoMember | undefined): string[] {
 
                 if (entry && typeof entry === 'object') {
                         const obj = entry as any;
-                        candidates.push(obj?.id, obj?.role_id, obj?.roleId, obj?.role?.id);
+                        candidates.push(obj?.role?.id, obj?.id, obj?.role_id, obj?.roleId);
                 }
 
                 candidates.push(entry);


### PR DESCRIPTION
## Summary
- prioritize nested role identifiers in collectMemberRoleIds before falling back to other properties
- extend collectMemberRoleIds tests to cover nested role id objects

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d66553a2d483229e8dcd009196039f