### PR TITLE
fix: normalize nested role entries for current user role detection

### DIFF
--- a/src/lib/utils/currentUserRoleIds.spec.ts
+++ b/src/lib/utils/currentUserRoleIds.spec.ts
@@ -74,6 +74,17 @@ describe('resolveCurrentUserRoleIds', () => {
                 expect(result.sort()).toEqual(['6666', '7777', '8888', '9999']);
         });
 
+        it('collectMemberRoleIds includes nested role identifiers', () => {
+                const member = {
+                        user: { id: currentUserId },
+                        roles: [{ role: { id: '5005' } }]
+                } as any;
+
+                const result = collectMemberRoleIds(member);
+
+                expect(result).toEqual(['5005']);
+        });
+
         it('collectMemberRoleIds picks nested role identifiers before raw entries', () => {
                 const member = {
                         user: { id: currentUserId },

--- a/src/lib/utils/currentUserRoleIds.ts
+++ b/src/lib/utils/currentUserRoleIds.ts
@@ -27,17 +27,24 @@ export function memberUserId(member: DtoMember | undefined): string | null {
 }
 
 export function collectMemberRoleIds(member: DtoMember | undefined): string[] {
-	if (!member) return [];
-	const roles = (member as any)?.roles;
-	const list = Array.isArray(roles) ? roles : [];
-	const seen = new Set<string>();
-	const result: string[] = [];
+        if (!member) return [];
+        const roles = (member as any)?.roles;
+        const list = Array.isArray(roles) ? roles : [];
+        const seen = new Set<string>();
+        const result: string[] = [];
         for (const entry of list) {
+                const nestedRoleId = toSnowflakeString((entry as any)?.role?.id);
+                if (nestedRoleId && !seen.has(nestedRoleId)) {
+                        seen.add(nestedRoleId);
+                        result.push(nestedRoleId);
+                        continue;
+                }
+
                 const candidates: unknown[] = [];
 
                 if (entry && typeof entry === 'object') {
                         const obj = entry as any;
-                        candidates.push(obj?.role?.id, obj?.id, obj?.role_id, obj?.roleId);
+                        candidates.push(obj?.id, obj?.role_id, obj?.roleId);
                 }
 
                 candidates.push(entry);


### PR DESCRIPTION
## Summary
- normalize current user role collection by checking nested role.id before legacy fallbacks
- add dedicated test coverage for members whose roles array includes nested role objects

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d66967a0148322b87df0711e4dcfd0