### PR TITLE
fix: prioritize nested member role ids

### DIFF
--- a/src/lib/utils/currentUserRoleIds.spec.ts
+++ b/src/lib/utils/currentUserRoleIds.spec.ts
@@ -85,6 +85,20 @@ describe('resolveCurrentUserRoleIds', () => {
                 expect(result).toEqual(['5005']);
         });
 
+        it('collectMemberRoleIds prioritizes nested role identifiers over fallback properties', () => {
+                const member = {
+                        user: { id: currentUserId },
+                        roles: [
+                                { role: { id: '5005' }, id: '9999', role_id: '8888', roleId: '7777' },
+                                { id: '6006' }
+                        ]
+                } as any;
+
+                const result = collectMemberRoleIds(member);
+
+                expect(result).toEqual(['5005', '6006']);
+        });
+
         it('collectMemberRoleIds picks nested role identifiers before raw entries', () => {
                 const member = {
                         user: { id: currentUserId },

--- a/src/lib/utils/currentUserRoleIds.ts
+++ b/src/lib/utils/currentUserRoleIds.ts
@@ -33,18 +33,11 @@ export function collectMemberRoleIds(member: DtoMember | undefined): string[] {
         const seen = new Set<string>();
         const result: string[] = [];
         for (const entry of list) {
-                const nestedRoleId = toSnowflakeString((entry as any)?.role?.id);
-                if (nestedRoleId && !seen.has(nestedRoleId)) {
-                        seen.add(nestedRoleId);
-                        result.push(nestedRoleId);
-                        continue;
-                }
-
                 const candidates: unknown[] = [];
 
                 if (entry && typeof entry === 'object') {
                         const obj = entry as any;
-                        candidates.push(obj?.id, obj?.role_id, obj?.roleId);
+                        candidates.push(obj?.role?.id, obj?.id, obj?.role_id, obj?.roleId);
                 }
 
                 candidates.push(entry);


### PR DESCRIPTION
## Summary
- ensure `collectMemberRoleIds` evaluates nested `role.id` values before fallback properties
- add tests that cover nested role identifiers and their precedence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d66d6d0f488322a6f001ef57a0cabf