### PR TITLE
Refactor channel access logic to rely on role intersections

### DIFF
--- a/src/lib/utils/channelRoles.ts
+++ b/src/lib/utils/channelRoles.ts
@@ -2,7 +2,6 @@ import { get } from 'svelte/store';
 import type { DtoChannel, GuildChannelRolePermission } from '$lib/api';
 import { auth } from '$lib/stores/auth';
 import { channelRolesByGuild } from '$lib/stores/appState';
-import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
 
 function toSnowflakeString(value: unknown): string | null {
 	if (value == null) return null;
@@ -84,34 +83,57 @@ export function getCachedChannelRoleIds(
 }
 
 export function channelAllowListedRoleIds(
-	guildId: string | number | bigint | null | undefined,
-	channel: Pick<DtoChannel, 'id' | 'roles'> | null | undefined,
-	snapshot?: Record<string, Record<string, string[]>>
+        guildId: string | number | bigint | null | undefined,
+        channel: Pick<DtoChannel, 'id' | 'roles'> | null | undefined,
+        snapshot?: Record<string, Record<string, string[]>>
 ): string[] {
-	const gid = toSnowflakeString(guildId ?? (channel as any)?.guild_id);
-	const cid = toSnowflakeString((channel as any)?.id);
-	if (!gid || !cid) return [];
-	const store = snapshot ?? get(channelRolesByGuild);
-	const stored = store?.[gid]?.[cid];
-	if (Array.isArray(stored)) {
-		return stored;
-	}
-	const inlineRoles = (channel as any)?.roles;
-	if (!Array.isArray(inlineRoles)) {
-		return [];
-	}
-	return filterViewableRoleIds(inlineRoles as any);
+        const gid = toSnowflakeString(guildId ?? (channel as any)?.guild_id);
+        const cid = toSnowflakeString((channel as any)?.id);
+        if (!gid || !cid) return [];
+        const store = snapshot ?? get(channelRolesByGuild);
+        const stored = store?.[gid]?.[cid];
+        if (Array.isArray(stored)) {
+                return stored;
+        }
+        const inlineRoles = (channel as any)?.roles;
+        if (!Array.isArray(inlineRoles)) {
+                return [];
+        }
+        return normalizeChannelRoleIds(inlineRoles as any);
+}
+
+export function normalizeChannelRoleIds(list: Iterable<any>): string[] {
+        const result: string[] = [];
+        const seen = new Set<string>();
+        for (const entry of list) {
+                const candidates: unknown[] = [];
+                if (entry && typeof entry === 'object') {
+                        const obj = entry as any;
+                        candidates.push(obj?.role?.id, obj?.id, obj?.role_id, obj?.roleId);
+                }
+                candidates.push(entry);
+
+                for (const candidate of candidates) {
+                        const id = toSnowflakeString(candidate);
+                        if (!id) continue;
+                        if (seen.has(id)) break;
+                        seen.add(id);
+                        result.push(id);
+                        break;
+                }
+        }
+        return result;
 }
 
 async function fetchChannelRoleIds(guildId: string, channelId: string): Promise<string[]> {
-	const response = await auth.api.guildRoles.guildGuildIdChannelChannelIdRolesGet({
-		guildId: toApiSnowflake(guildId),
-		channelId: toApiSnowflake(channelId)
-	});
-	const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
-	const ids = filterViewableRoleIds(list);
-	setCacheEntry(guildId, channelId, ids);
-	return ids;
+        const response = await auth.api.guildRoles.guildGuildIdChannelChannelIdRolesGet({
+                guildId: toApiSnowflake(guildId),
+                channelId: toApiSnowflake(channelId)
+        });
+        const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
+        const ids = normalizeChannelRoleIds(list as any);
+        setCacheEntry(guildId, channelId, ids);
+        return ids;
 }
 
 export async function loadChannelRoleIds(

--- a/src/lib/utils/guildRoles.ts
+++ b/src/lib/utils/guildRoles.ts
@@ -2,7 +2,7 @@ import { get } from 'svelte/store';
 import type { DtoChannel, DtoRole, GuildChannelRolePermission } from '$lib/api';
 import { auth } from '$lib/stores/auth';
 import { channelRolesByGuild } from '$lib/stores/appState';
-import { filterViewableRoleIds } from '$lib/utils/channelRolePermissions';
+import { normalizeChannelRoleIds } from '$lib/utils/channelRoles';
 
 const guildRolesResolved = new Map<string, DtoRole[]>();
 const guildRolesInFlight = new Map<string, Promise<DtoRole[]>>();
@@ -193,7 +193,7 @@ async function fetchChannelRoleIds(guildId: string, channelId: string): Promise<
                 channelId: toApiSnowflake(channelId)
         });
         const list = ((response as any)?.data ?? response ?? []) as GuildChannelRolePermission[];
-        const ids = filterViewableRoleIds(list);
+        const ids = normalizeChannelRoleIds(list as any);
         setChannelRoleCacheEntry(guildId, channelId, ids);
         return ids;
 }

--- a/src/lib/utils/memberChannelAccess.spec.ts
+++ b/src/lib/utils/memberChannelAccess.spec.ts
@@ -1,63 +1,53 @@
 import { describe, expect, it } from 'vitest';
 import { memberHasChannelAccess } from '$lib/utils/memberChannelAccess';
 import { collectMemberRoleIds } from '$lib/utils/currentUserRoleIds';
-import { PERMISSION_VIEW_CHANNEL, PERMISSION_ADMINISTRATOR } from '$lib/utils/permissions';
 
 describe('memberHasChannelAccess', () => {
 	const guildId = '1001';
 	const baseChannel = { private: true } as const;
 	const baseGuild = { owner: '9999' } as const;
 
-	it('denies members without allow-listed roles in a private channel', () => {
-		const member = { user: { id: '101' } } as any;
-		const roleIds = ['2002', guildId];
-		const result = memberHasChannelAccess({
-			member,
-			channel: baseChannel,
-			guild: baseGuild,
-			guildId,
-			roleIds,
-			basePermissions: PERMISSION_VIEW_CHANNEL,
-			channelOverrides: {},
-			allowListedRoleIds: ['3003'],
-			viewPermissionBit: PERMISSION_VIEW_CHANNEL
-		});
-
-		expect(result).toBe(false);
-	});
-
-	it('allows members with an allow-listed role in a private channel', () => {
-		const member = { user: { id: '102' } } as any;
-		const roleIds = ['3003', guildId];
-		const result = memberHasChannelAccess({
-			member,
-			channel: baseChannel,
-			guild: baseGuild,
-			guildId,
-			roleIds,
-			basePermissions: PERMISSION_VIEW_CHANNEL,
-			channelOverrides: {},
-			allowListedRoleIds: ['3003'],
-			viewPermissionBit: PERMISSION_VIEW_CHANNEL
-		});
-
-		expect(result).toBe(true);
-	});
-
-        it('allows administrators even without allow-listed roles', () => {
-                const member = { user: { id: '103' } } as any;
-                const roleIds = ['4004', guildId];
+        it('denies members without allow-listed roles in a private channel', () => {
+                const member = { user: { id: '101' } } as any;
+                const memberRoleIds = ['2002', guildId];
                 const result = memberHasChannelAccess({
                         member,
-			channel: baseChannel,
-			guild: baseGuild,
-			guildId,
-			roleIds,
-			basePermissions: PERMISSION_ADMINISTRATOR,
-			channelOverrides: {},
-			allowListedRoleIds: ['3003'],
-			viewPermissionBit: PERMISSION_VIEW_CHANNEL
-		});
+                        channel: baseChannel,
+                        guild: baseGuild,
+                        guildId,
+                        memberRoleIds,
+                        channelRoleIds: ['3003']
+                });
+
+                expect(result).toBe(false);
+        });
+
+        it('allows members with an allow-listed role in a private channel', () => {
+                const member = { user: { id: '102' } } as any;
+                const memberRoleIds = ['3003', guildId];
+                const result = memberHasChannelAccess({
+                        member,
+                        channel: baseChannel,
+                        guild: baseGuild,
+                        guildId,
+                        memberRoleIds,
+                        channelRoleIds: ['3003']
+                });
+
+                expect(result).toBe(true);
+        });
+
+        it('allows administrators even without allow-listed roles', () => {
+                const member = { user: { id: '103' }, administrator: true } as any;
+                const memberRoleIds = ['4004', guildId];
+                const result = memberHasChannelAccess({
+                        member,
+                        channel: baseChannel,
+                        guild: baseGuild,
+                        guildId,
+                        memberRoleIds,
+                        channelRoleIds: ['3003']
+                });
 
         expect(result).toBe(true);
         });
@@ -67,18 +57,15 @@ describe('memberHasChannelAccess', () => {
                         user: { id: '104' },
                         roles: [{ roleId: '5004' }]
                 } as any;
-                const roleIds = [...collectMemberRoleIds(member), guildId];
+                const memberRoleIds = [...collectMemberRoleIds(member), guildId];
 
                 const result = memberHasChannelAccess({
                         member,
                         channel: baseChannel,
                         guild: baseGuild,
                         guildId,
-                        roleIds,
-                        basePermissions: PERMISSION_VIEW_CHANNEL,
-                        channelOverrides: {},
-                        allowListedRoleIds: ['5004'],
-                        viewPermissionBit: PERMISSION_VIEW_CHANNEL
+                        memberRoleIds,
+                        channelRoleIds: ['5004']
                 });
 
                 expect(result).toBe(true);
@@ -91,19 +78,16 @@ describe('memberHasChannelAccess', () => {
                 } as any;
                 const baseRoleIds = collectMemberRoleIds(member);
                 expect(baseRoleIds).toEqual(['5005']);
-                const roleIds = [...baseRoleIds, guildId];
-                expect(roleIds).toEqual(['5005', guildId]);
+                const memberRoleIds = [...baseRoleIds, guildId];
+                expect(memberRoleIds).toEqual(['5005', guildId]);
 
                 const result = memberHasChannelAccess({
                         member,
                         channel: baseChannel,
                         guild: baseGuild,
                         guildId,
-                        roleIds,
-                        basePermissions: PERMISSION_VIEW_CHANNEL,
-                        channelOverrides: {},
-                        allowListedRoleIds: ['5005'],
-                        viewPermissionBit: PERMISSION_VIEW_CHANNEL
+                        memberRoleIds,
+                        channelRoleIds: ['5005']
                 });
 
                 expect(result).toBe(true);


### PR DESCRIPTION
## Summary
- simplify member channel access resolution to use owner/admin flags and channel role intersections
- return raw channel role IDs from role helpers and adjust caching/tests
- streamline MemberPane to drop override fetching and align debug instrumentation with the new logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67ee0bf18832282c6dcb7e88b2e47