### PR TITLE
fix: soften modal overlays with backdrop blur

### DIFF
--- a/src/lib/components/app/search/SearchPanel.svelte
+++ b/src/lib/components/app/search/SearchPanel.svelte
@@ -441,9 +441,10 @@
                         }
                 }}
         >
+                <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
                 <div
                         bind:this={panelEl}
-                        class="panel absolute w-[min(90vw,720px)] p-5"
+                        class="panel absolute z-10 w-[min(90vw,720px)] p-5"
                         role="dialog"
                         tabindex="-1"
                         style={`left:${posX}px; top:${posY}px`}

--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -1535,7 +1535,7 @@
 				if (e.key === 'Enter') saveEditCategory();
 			}}
 		>
-			<div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 			<div
 				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
 				role="document"
@@ -1576,7 +1576,7 @@
 				if (e.key === 'Enter') createChannel();
 			}}
 		>
-			<div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 			<div
 				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
 				role="document"
@@ -1624,7 +1624,7 @@
 				if (e.key === 'Enter') createCategory();
 			}}
 		>
-			<div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 			<div
 				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
 				role="document"

--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -161,7 +161,7 @@
 				if (e.key === 'Enter') createGuild();
 			}}
 		>
-			<div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 			<div
 				class="panel absolute top-1/2 left-1/2 w-64 -translate-x-1/2 -translate-y-1/2 p-3"
 				role="document"
@@ -200,7 +200,7 @@
 				if (e.key === 'Enter') confirmLeaveGuild();
 			}}
 		>
-			<div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
 			<div
 				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-4"
 				role="document"


### PR DESCRIPTION
## Summary
- add a subtle backdrop blur to server creation and leave confirmations
- apply the same blurred overlay to channel and category dialogs
- introduce a blurred overlay behind the floating search panel and layer the panel above it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6b93a4c44832293ed1f937835d5cd