### PR TITLE
fix: adjust modal overlays to isolate blur

### DIFF
--- a/src/lib/components/app/search/SearchPanel.svelte
+++ b/src/lib/components/app/search/SearchPanel.svelte
@@ -441,95 +441,100 @@
                         }
                 }}
         >
-                <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
+                <div class="absolute inset-0 bg-black/40"></div>
                 <div
-                        bind:this={panelEl}
-                        class="panel absolute z-10 w-[min(90vw,720px)] p-5"
-                        role="dialog"
-                        tabindex="-1"
+                        class="absolute z-10"
                         style={`left:${posX}px; top:${posY}px`}
-                        onpointerdown={(e) => e.stopPropagation()}
                 >
-                        <div class="flex flex-col gap-3">
+                        <div class="relative">
+                                <div class="pointer-events-none absolute inset-0 z-0 rounded-xl bg-[var(--panel)]/30 backdrop-blur-sm"></div>
                                 <div
-                                        class="relative"
-                                        onpointerdown={(event) => {
-                                                if (
-                                                        showKeywordHelp &&
-                                                        !(event.target as HTMLElement | null)?.closest('#search-filter-help') &&
-                                                        !(event.target as HTMLElement | null)?.closest('#search-filter-help-button')
-                                                ) {
-                                                        showKeywordHelp = false;
-                                                }
-                                        }}
+                                        bind:this={panelEl}
+                                        class="panel relative z-10 w-[min(90vw,720px)] p-5"
+                                        role="dialog"
+                                        tabindex="-1"
+                                        onpointerdown={(e) => e.stopPropagation()}
                                 >
-                                        <div
-                                                class="flex min-h-12 flex-wrap items-center gap-2 rounded-lg border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2 text-sm shadow-sm transition focus-within:border-[var(--brand)] focus-within:shadow-[0_0_0_2px_var(--brand)]"
-                                        >
-                                                <Search class="h-5 w-5 text-[var(--muted)]" stroke-width={2} />
-                                                {#if authorFilter}
-                                                        <span
-                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
+                                        <div class="flex flex-col gap-3">
+                                                <div
+                                                        class="relative"
+                                                        onpointerdown={(event) => {
+                                                                if (
+                                                                        showKeywordHelp &&
+                                                                        !(event.target as HTMLElement | null)?.closest('#search-filter-help') &&
+                                                                        !(event.target as HTMLElement | null)?.closest('#search-filter-help-button')
+                                                                ) {
+                                                                        showKeywordHelp = false;
+                                                                }
+                                                        }}
+                                                >
+                                                        <div
+                                                                class="flex min-h-12 flex-wrap items-center gap-2 rounded-lg border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2 text-sm shadow-sm transition focus-within:border-[var(--brand)] focus-within:shadow-[0_0_0_2px_var(--brand)]"
                                                         >
-                                                                <span class="font-semibold text-[var(--muted)]">
-                                                                        {m.search_filter_from()}
-                                                                </span>
-                                                                <span>{authorFilter.display}</span>
-                                                                <button
-                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
-                                                                        type="button"
-                                                                        aria-label={m.search_filter_remove()}
-                                                                        onclick={(event) => {
-                                                                                event.stopPropagation();
-                                                                                removeAuthor();
-                                                                        }}
-                                                                >
-                                                                        ×
-                                                                </button>
-                                                        </span>
-                                                {/if}
-                                                {#each mentionFilters as mention, index}
-                                                        <span
-                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
-                                                        >
-                                                                <span class="font-semibold text-[var(--muted)]">
-                                                                        {m.search_filter_mentions()}
-                                                                </span>
-                                                                <span>{mention.display}</span>
-                                                                <button
-                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
-                                                                        type="button"
-                                                                        aria-label={m.search_filter_remove()}
-                                                                        onclick={(event) => {
-                                                                                event.stopPropagation();
-                                                                                removeMention(index);
-                                                                        }}
-                                                                >
-                                                                        ×
-                                                                </button>
-                                                        </span>
-                                                {/each}
-                                                {#each hasSelected as option}
-                                                        <span
-                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
-                                                        >
-                                                                <span class="font-semibold text-[var(--muted)]">
-                                                                        {m.search_filter_has()}
-                                                                </span>
-                                                                <span>{hasLabel(option)}</span>
-                                                                <button
-                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
-                                                                        type="button"
-                                                                        aria-label={m.search_filter_remove()}
-                                                                        onclick={(event) => {
-                                                                                event.stopPropagation();
-                                                                                removeHas(option);
-                                                                        }}
-                                                                >
-                                                                        ×
-                                                                </button>
-                                                        </span>
-                                                {/each}
+                                                                <Search class="h-5 w-5 text-[var(--muted)]" stroke-width={2} />
+                                                                {#if authorFilter}
+                                                                        <span
+                                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
+                                                                        >
+                                                                                <span class="font-semibold text-[var(--muted)]">
+                                                                                        {m.search_filter_from()}
+                                                                                </span>
+                                                                                <span>{authorFilter.display}</span>
+                                                                                <button
+                                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
+                                                                                        type="button"
+                                                                                        aria-label={m.search_filter_remove()}
+                                                                                        onclick={(event) => {
+                                                                                                event.stopPropagation();
+                                                                                                removeAuthor();
+                                                                                        }}
+                                                                                >
+                                                                                        ×
+                                                                                </button>
+                                                                        </span>
+                                                                {/if}
+                                                                {#each mentionFilters as mention, index}
+                                                                        <span
+                                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
+                                                                        >
+                                                                                <span class="font-semibold text-[var(--muted)]">
+                                                                                        {m.search_filter_mentions()}
+                                                                                </span>
+                                                                                <span>{mention.display}</span>
+                                                                                <button
+                                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
+                                                                                        type="button"
+                                                                                        aria-label={m.search_filter_remove()}
+                                                                                        onclick={(event) => {
+                                                                                                event.stopPropagation();
+                                                                                                removeMention(index);
+                                                                                        }}
+                                                                                >
+                                                                                        ×
+                                                                                </button>
+                                                                        </span>
+                                                                {/each}
+                                                                {#each hasSelected as option}
+                                                                        <span
+                                                                                class="flex items-center gap-1 rounded-full bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]"
+                                                                        >
+                                                                                <span class="font-semibold text-[var(--muted)]">
+                                                                                        {m.search_filter_has()}
+                                                                                </span>
+                                                                                <span>{hasLabel(option)}</span>
+                                                                                <button
+                                                                                        class="rounded-full bg-transparent p-1 text-[var(--muted)] hover:bg-[var(--panel-strong)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--brand)]/40"
+                                                                                        type="button"
+                                                                                        aria-label={m.search_filter_remove()}
+                                                                                        onclick={(event) => {
+                                                                                                event.stopPropagation();
+                                                                                                removeHas(option);
+                                                                                        }}
+                                                                                >
+                                                                                        ×
+                                                                                </button>
+                                                                        </span>
+                                                                {/each}
                                                 {#if pendingFilter === 'from' || pendingFilter === 'mentions'}
                                                         <div class="flex items-center gap-2 rounded-md border border-[var(--stroke)] bg-[var(--panel)] px-2 py-1 text-xs text-[var(--fg)]">
                                                                 <span class="font-semibold text-[var(--muted)]">
@@ -801,6 +806,8 @@
                                                 </button>
                                         </div>
                                 {/if}
+                        </div>
+                                </div>
                         </div>
                 </div>
         </div>

--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -1539,35 +1539,40 @@
 				if (e.key === 'Enter') saveEditCategory();
 			}}
 		>
-                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
-			<div
-				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
-				role="document"
-				tabindex="-1"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
-				<div class="mb-2 text-sm font-medium">{m.edit_category()}</div>
-				{#if editCategoryError}
-					<div class="mb-2 text-sm text-red-500">{editCategoryError}</div>
-				{/if}
-				<input
-					class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
-					placeholder={m.category_name()}
-					bind:value={editCategoryName}
-				/>
-				<div class="flex justify-end gap-2">
-					<button
-						class="rounded-md border border-[var(--stroke)] px-3 py-1"
-						onclick={() => (editingCategory = null)}>{m.cancel()}</button
-					>
-					<button
-						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
-						onclick={saveEditCategory}>{m.save()}</button
-					>
-				</div>
-			</div>
-		</div>
-	{/if}
+                        <div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                                <div class="relative">
+                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
+                                        <div
+                                                class="panel relative z-10 w-72 p-3"
+                                                role="document"
+                                                tabindex="-1"
+                                                onpointerdown={(e) => e.stopPropagation()}
+                                        >
+                                                <div class="mb-2 text-sm font-medium">{m.edit_category()}</div>
+                                                {#if editCategoryError}
+                                                        <div class="mb-2 text-sm text-red-500">{editCategoryError}</div>
+                                                {/if}
+                                                <input
+                                                        class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
+                                                        placeholder={m.category_name()}
+                                                        bind:value={editCategoryName}
+                                                />
+                                                <div class="flex justify-end gap-2">
+                                                        <button
+                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
+                                                                onclick={() => (editingCategory = null)}>{m.cancel()}</button
+                                                        >
+                                                        <button
+                                                                class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
+                                                                onclick={saveEditCategory}>{m.save()}</button
+                                                        >
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        {/if}
 
 	{#if creatingChannel}
 		<div
@@ -1580,42 +1585,47 @@
 				if (e.key === 'Enter') createChannel();
 			}}
 		>
-                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
-			<div
-				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
-				role="document"
-				tabindex="-1"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
-				<div class="mb-2 text-sm font-medium">{m.new_channel()}</div>
-				{#if channelError}
-					<div class="mb-2 text-sm text-red-500">{channelError}</div>
-				{/if}
-				<input
-					class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
-					placeholder={m.channel_name()}
-					bind:value={newChannelName}
-				/>
-				{#if creatingChannelParent}
-					<div class="mb-2 text-xs text-[var(--muted)]">in category #{creatingChannelParent}</div>
-				{/if}
-				<label class="mb-2 flex items-center gap-2 text-sm">
-					<input type="checkbox" bind:checked={newChannelPrivate} />
-					{m.channel_private()}
-				</label>
-				<div class="flex justify-end gap-2">
-					<button
-						class="rounded-md border border-[var(--stroke)] px-3 py-1"
-						onclick={() => (creatingChannel = false)}>{m.cancel()}</button
-					>
-					<button
-						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
-						onclick={createChannel}>{m.create()}</button
-					>
-				</div>
-			</div>
-		</div>
-	{/if}
+                        <div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                                <div class="relative">
+                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
+                                        <div
+                                                class="panel relative z-10 w-72 p-3"
+                                                role="document"
+                                                tabindex="-1"
+                                                onpointerdown={(e) => e.stopPropagation()}
+                                        >
+                                                <div class="mb-2 text-sm font-medium">{m.new_channel()}</div>
+                                                {#if channelError}
+                                                        <div class="mb-2 text-sm text-red-500">{channelError}</div>
+                                                {/if}
+                                                <input
+                                                        class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
+                                                        placeholder={m.channel_name()}
+                                                        bind:value={newChannelName}
+                                                />
+                                                {#if creatingChannelParent}
+                                                        <div class="mb-2 text-xs text-[var(--muted)]">in category #{creatingChannelParent}</div>
+                                                {/if}
+                                                <label class="mb-2 flex items-center gap-2 text-sm">
+                                                        <input type="checkbox" bind:checked={newChannelPrivate} />
+                                                        {m.channel_private()}
+                                                </label>
+                                                <div class="flex justify-end gap-2">
+                                                        <button
+                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
+                                                                onclick={() => (creatingChannel = false)}>{m.cancel()}</button
+                                                        >
+                                                        <button
+                                                                class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
+                                                                onclick={createChannel}>{m.create()}</button
+                                                        >
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        {/if}
 
 	{#if creatingCategory}
 		<div
@@ -1628,33 +1638,38 @@
 				if (e.key === 'Enter') createCategory();
 			}}
 		>
-                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
-			<div
-				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-3"
-				role="document"
-				tabindex="-1"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
-				<div class="mb-2 text-sm font-medium">{m.new_category()}</div>
-				{#if categoryError}
-					<div class="mb-2 text-sm text-red-500">{categoryError}</div>
-				{/if}
-				<input
-					class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
-					placeholder={m.category_name()}
-					bind:value={newCategoryName}
-				/>
-				<div class="flex justify-end gap-2">
-					<button
-						class="rounded-md border border-[var(--stroke)] px-3 py-1"
-						onclick={() => (creatingCategory = false)}>{m.cancel()}</button
-					>
-					<button
-						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
-						onclick={createCategory}>{m.create()}</button
-					>
-				</div>
-			</div>
-		</div>
-	{/if}
+                        <div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                                <div class="relative">
+                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
+                                        <div
+                                                class="panel relative z-10 w-72 p-3"
+                                                role="document"
+                                                tabindex="-1"
+                                                onpointerdown={(e) => e.stopPropagation()}
+                                        >
+                                                <div class="mb-2 text-sm font-medium">{m.new_category()}</div>
+                                                {#if categoryError}
+                                                        <div class="mb-2 text-sm text-red-500">{categoryError}</div>
+                                                {/if}
+                                                <input
+                                                        class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
+                                                        placeholder={m.category_name()}
+                                                        bind:value={newCategoryName}
+                                                />
+                                                <div class="flex justify-end gap-2">
+                                                        <button
+                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
+                                                                onclick={() => (creatingCategory = false)}>{m.cancel()}</button
+                                                        >
+                                                        <button
+                                                                class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
+                                                                onclick={createCategory}>{m.create()}</button
+                                                        >
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        {/if}
 </div>

--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -161,33 +161,38 @@
 				if (e.key === 'Enter') createGuild();
 			}}
 		>
-                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
-			<div
-				class="panel absolute top-1/2 left-1/2 w-64 -translate-x-1/2 -translate-y-1/2 p-3"
-				role="document"
-				tabindex="-1"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
-				<div class="mb-2 text-sm font-medium">{m.new_server()}</div>
-				{#if error}<div class="mb-2 text-sm text-red-500">{error}</div>{/if}
-				<input
-					class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
-					placeholder={m.server_name()}
-					bind:value={newGuildName}
-				/>
-				<div class="flex justify-end gap-2">
-					<button
-						class="rounded-md border border-[var(--stroke)] px-3 py-1"
-						onclick={() => (creating = false)}>{m.cancel()}</button
-					>
-					<button
-						class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
-						onclick={createGuild}>{m.create()}</button
-					>
-				</div>
-			</div>
-		</div>
-	{/if}
+                        <div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                                <div class="relative">
+                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
+                                        <div
+                                                class="panel relative z-10 w-64 p-3"
+                                                role="document"
+                                                tabindex="-1"
+                                                onpointerdown={(e) => e.stopPropagation()}
+                                        >
+                                                <div class="mb-2 text-sm font-medium">{m.new_server()}</div>
+                                                {#if error}<div class="mb-2 text-sm text-red-500">{error}</div>{/if}
+                                                <input
+                                                        class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
+                                                        placeholder={m.server_name()}
+                                                        bind:value={newGuildName}
+                                                />
+                                                <div class="flex justify-end gap-2">
+                                                        <button
+                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
+                                                                onclick={() => (creating = false)}>{m.cancel()}</button
+                                                        >
+                                                        <button
+                                                                class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
+                                                                onclick={createGuild}>{m.create()}</button
+                                                        >
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        {/if}
 
 	{#if leavingGuild}
 		<div
@@ -200,30 +205,35 @@
 				if (e.key === 'Enter') confirmLeaveGuild();
 			}}
 		>
-                        <div class="absolute inset-0 bg-black/40 backdrop-blur-sm"></div>
-			<div
-				class="panel absolute top-1/2 left-1/2 w-72 -translate-x-1/2 -translate-y-1/2 p-4"
-				role="document"
-				tabindex="-1"
-				onpointerdown={(e) => e.stopPropagation()}
-			>
-				<div class="mb-2 text-base font-semibold">{m.leave_server_confirm_title({ server: leavingGuild.name })}</div>
-				<p class="mb-4 text-sm text-[var(--muted)]">{m.leave_server_confirm_description({ server: leavingGuild.name })}</p>
-				<div class="flex justify-end gap-2">
-					<button
-						class="rounded-md border border-[var(--stroke)] px-3 py-1"
-						onclick={() => (leavingGuild = null)}
-					>
-						{m.cancel()}
-					</button>
-					<button
-						class="rounded-md bg-[var(--danger)] px-3 py-1 text-[var(--bg)]"
-						onclick={confirmLeaveGuild}
-					>
-						{m.leave_server()}
-					</button>
-				</div>
-			</div>
-		</div>
-	{/if}
+                        <div class="absolute inset-0 bg-black/40"></div>
+                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+                                <div class="relative">
+                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
+                                        <div
+                                                class="panel relative z-10 w-72 p-4"
+                                                role="document"
+                                                tabindex="-1"
+                                                onpointerdown={(e) => e.stopPropagation()}
+                                        >
+                                                <div class="mb-2 text-base font-semibold">{m.leave_server_confirm_title({ server: leavingGuild.name })}</div>
+                                                <p class="mb-4 text-sm text-[var(--muted)]">{m.leave_server_confirm_description({ server: leavingGuild.name })}</p>
+                                                <div class="flex justify-end gap-2">
+                                                        <button
+                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
+                                                                onclick={() => (leavingGuild = null)}
+                                                        >
+                                                                {m.cancel()}
+                                                        </button>
+                                                        <button
+                                                                class="rounded-md bg-[var(--danger)] px-3 py-1 text-[var(--bg)]"
+                                                                onclick={confirmLeaveGuild}
+                                                        >
+                                                                {m.leave_server()}
+                                                        </button>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        {/if}
 </div>


### PR DESCRIPTION
## Summary
- remove the global backdrop blur from server dialogs, channel modals, and the search overlay while keeping the viewport tint
- wrap each modal panel in a relative container that adds a panel-sized pointer-events-none blur layer between the tint and interactive content

## Testing
- npm run lint *(fails: repository has existing Prettier formatting violations)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb9a15c083229e6ecdd6f0198f86