### PR TITLE
fix: clear edit channel state on cancel

### DIFF
--- a/src/lib/components/app/sidebar/ChannelPane.svelte
+++ b/src/lib/components/app/sidebar/ChannelPane.svelte
@@ -1512,7 +1512,10 @@
 				<div class="flex justify-end gap-2">
                                         <button
                                                 class="rounded-md border border-[var(--stroke)] px-3 py-1"
-                                                onclick={() => dismissPanel?.()}
+                                                onclick={() => {
+                                                        dismissPanel?.();
+                                                        closeEditChannel();
+                                                }}
                                         >
                                                 {m.cancel()}
                                         </button>


### PR DESCRIPTION
## Summary
- ensure the edit channel dialog cancel action always clears the editing state even without the close slot handler

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d76f6e16808322be7597414f3c4456