### PR TITLE
feat: support jumping to searched messages

### DIFF
--- a/src/lib/components/app/chat/MessageItem.svelte
+++ b/src/lib/components/app/chat/MessageItem.svelte
@@ -732,25 +732,32 @@
 		}).format(d);
 	}
 
-	function fmtEditFull(m: DtoMessage) {
-		if (!m.updated_at) return '';
-		const d = new Date(m.updated_at);
-		if (Number.isNaN(d.getTime())) return '';
-		return new Intl.DateTimeFormat(undefined, {
+        function fmtEditFull(m: DtoMessage) {
+                if (!m.updated_at) return '';
+                const d = new Date(m.updated_at);
+                if (Number.isNaN(d.getTime())) return '';
+                return new Intl.DateTimeFormat(undefined, {
 			year: 'numeric',
 			month: 'short',
 			day: '2-digit',
 			hour: '2-digit',
 			minute: '2-digit',
-			second: '2-digit'
-		}).format(d);
-	}
+                        second: '2-digit'
+                }).format(d);
+        }
 
-	async function saveEdit() {
-		if (!$selectedChannelId || !message.id) return;
-		saving = true;
-		try {
-			await auth.api.message.messageChannelChannelIdMessageIdPatch({
+        function messageDomId(value: any): string {
+                if (value == null) return '';
+                const str = String(value);
+                const digits = str.replace(/[^0-9]/g, '');
+                return digits || str;
+        }
+
+        async function saveEdit() {
+                if (!$selectedChannelId || !message.id) return;
+                saving = true;
+                try {
+                        await auth.api.message.messageChannelChannelIdMessageIdPatch({
 				channelId: $selectedChannelId as any,
 				messageId: message.id as any,
 				messageUpdateMessageRequest: { content: draft }
@@ -838,10 +845,11 @@
 </script>
 
 <div
-	role="listitem"
-	class={`group/message flex gap-3 px-4 ${compact ? 'py-0.5' : 'py-2'} hover:bg-[var(--panel)]/30`}
-	onpointerup={handleRootPointerUp}
-	oncontextmenu={openMessageMenu}
+        role="listitem"
+        class={`group/message flex gap-3 px-4 ${compact ? 'py-0.5' : 'py-2'} hover:bg-[var(--panel)]/30`}
+        onpointerup={handleRootPointerUp}
+        oncontextmenu={openMessageMenu}
+        data-message-id={messageDomId((message as any)?.id)}
 >
 	{#if compact}
 		<div

--- a/src/lib/stores/appState.ts
+++ b/src/lib/stores/appState.ts
@@ -22,5 +22,14 @@ export const lastChannelByGuild = writable<Record<string, string>>({});
 // Gate to control when MessageList is allowed to fetch
 export const channelReady = writable(false);
 
+// Cross-component request to jump to a specific message within a channel
+export const messageJumpRequest = writable<
+        | {
+                channelId: string;
+                messageId: string;
+        }
+        | null
+>(null);
+
 // Guild settings overlay state
 export const guildSettingsOpen = writable(false);

--- a/src/lib/stores/auth.ts
+++ b/src/lib/stores/auth.ts
@@ -99,10 +99,13 @@ function createAuthStore() {
 	async function refresh(): Promise<boolean> {
 		const rt = get(refreshToken);
 		if (!rt) return false;
-		try {
-			const res = await refreshApi.auth.authRefreshGet({
-				headers: { Authorization: `Bearer ${rt}` }
-			});
+                try {
+                        const headerValue = rt.startsWith('Bearer ')
+                                ? rt
+                                : `Bearer ${rt}`;
+                        const res = await refreshApi.auth.authRefreshGet({
+                                authentication: headerValue
+                        });
 			const t = res.data.token ?? '';
 			const r = res.data.refresh_token ?? '';
 			if (t) token.set(t);


### PR DESCRIPTION
## Summary
- add a shared message jump request store and trigger it from search results when a message is opened
- load message context with the new `around` direction, merge results without duplicates, and scroll to the target message
- update the auth refresh call to pass the refresh token via the new client argument

## Testing
- npm run lint *(fails: Cannot find package 'prettier-plugin-svelte')*

------
https://chatgpt.com/codex/tasks/task_e_68dad82ce0cc83229d55f9ff080bde72