### PR TITLE
fix: guard folder expansion effect

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -180,7 +180,12 @@
                 for (const item of displayItems) {
                         if (item.type === 'folder') {
                                 if (item.guilds.some((g) => g.guildId === selected)) {
-                                        expandedFolders = { ...expandedFolders, [item.folder.id]: true };
+                                        if (!expandedFolders[item.folder.id]) {
+                                                expandedFolders = {
+                                                        ...expandedFolders,
+                                                        [item.folder.id]: true
+                                                };
+                                        }
                                 }
                         }
                 }


### PR DESCRIPTION
## Summary
- avoid reassigning expanded folder state when the selected guild's folder is already expanded

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e092cdb16c832299c56f9945811947