### PR TITLE
fix: center folder controls in server bar

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -407,7 +407,7 @@
                                         </button>
                                 </div>
                         {:else}
-                                <div class="flex flex-col gap-2">
+                                <div class="flex flex-col items-center gap-2">
                                         <div class="relative">
                                                 <div
                                                         class={`absolute top-1/2 -left-2 w-1 -translate-y-1/2 rounded-full bg-[var(--brand)] transition-all ${
@@ -463,7 +463,7 @@
 
                                         {#if expandedFolders[item.folder.id]}
                                                 <div
-                                                        class="mt-2 flex flex-col gap-2 rounded-2xl border border-[var(--stroke)] p-2"
+                                                        class="mt-2 flex w-full flex-col gap-2 self-stretch rounded-2xl border border-[var(--stroke)] p-2"
                                                         style:background="color-mix(in srgb, var(--panel-strong) 70%, transparent)"
                                                 >
                                                         <div


### PR DESCRIPTION
## Summary
- center the folder wrapper so the folder button stays put when the list toggles
- ensure the expanded folder panel stretches to full width after centering

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e094428f3483228e2c5e4c473abe46