### PR TITLE
fix: center expanded folder guild buttons

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -463,11 +463,11 @@
 
                                         {#if expandedFolders[item.folder.id]}
                                                 <div
-                                                        class="mt-2 flex w-full flex-col gap-2 self-stretch rounded-2xl border border-[var(--stroke)] p-2"
+                                                        class="mt-2 flex flex-col items-center gap-2 rounded-2xl border border-[var(--stroke)] p-2"
                                                         style:background="color-mix(in srgb, var(--panel-strong) 70%, transparent)"
                                                 >
                                                         <div
-                                                                class={`h-2 rounded bg-[var(--brand)] transition-opacity ${
+                                                                class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
                                                                         folderDropTarget?.folderId === item.folder.id && folderDropTarget.index === 0
                                                                                 ? 'opacity-80'
                                                                                 : 'opacity-0'


### PR DESCRIPTION
## Summary
- center the expanded folder guild list by dropping the forced stretch utilities
- keep folder drag-and-drop indicators spanning the container with explicit width styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09656f0e883229fb28398de1f8e78