### PR TITLE
fix: avoid auto-expanding manually collapsed folders

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -178,16 +178,16 @@
                 const selected = $selectedGuildId;
                 if (!selected) return;
                 for (const item of displayItems) {
-                        if (item.type === 'folder') {
-                                if (item.guilds.some((g) => g.guildId === selected)) {
-                                        if (!expandedFolders[item.folder.id]) {
-                                                expandedFolders = {
-                                                        ...expandedFolders,
-                                                        [item.folder.id]: true
-                                                };
-                                        }
-                                }
+                        if (item.type !== 'folder') continue;
+                        if (!item.guilds.some((g) => g.guildId === selected)) continue;
+
+                        if (!Object.prototype.hasOwnProperty.call(expandedFolders, item.folder.id)) {
+                                expandedFolders = {
+                                        ...expandedFolders,
+                                        [item.folder.id]: true
+                                };
                         }
+                        break;
                 }
         });
 


### PR DESCRIPTION
## Summary
- prevent the server list sidebar from reopening folders that have already been manually collapsed
- keep the auto-expand behavior for first-time selections so selected guilds are still discoverable

## Testing
- `npm run lint` *(fails: existing Prettier formatting issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e097c66cb883228499f5c8343ff31e