### PR TITLE
fix: extend server folder highlight container

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -407,25 +407,27 @@
                                         </button>
                                 </div>
                         {:else}
-                                <div class="flex flex-col items-center gap-2">
+                                {@const folderHasSelection = item.guilds.some((g) => isGuildSelected(g.guildId))}
+                                {@const folderIsDropTarget = folderDropTarget?.folderId === item.folder.id}
+                                <div
+                                        class={`group relative flex flex-col items-center gap-2 rounded-2xl ${
+                                                folderIsDropTarget
+                                                        ? 'ring-2 ring-[var(--brand)]'
+                                                        : folderHasSelection
+                                                                ? 'ring-2 ring-[var(--brand)] ring-inset shadow'
+                                                                : ''
+                                        }`}
+                                >
                                         <div class="relative">
                                                 <div
                                                         class={`absolute top-1/2 -left-2 w-1 -translate-y-1/2 rounded-full bg-[var(--brand)] transition-all ${
-                                                                item.guilds.some((g) => isGuildSelected(g.guildId))
+                                                                folderHasSelection
                                                                         ? 'h-6 opacity-100'
                                                                         : 'h-2 opacity-0 group-hover:h-4 group-hover:opacity-60'
                                                         }`}
                                                 ></div>
                                                 <button
-                                                        class={`flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] p-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
-                                                                item.guilds.some((g) => isGuildSelected(g.guildId))
-                                                                        ? 'shadow ring-2 ring-[var(--brand)] ring-inset'
-                                                                        : ''
-                                                        } ${
-                                                                folderDropTarget?.folderId === item.folder.id
-                                                                        ? 'ring-2 ring-[var(--brand)]'
-                                                                        : ''
-                                                        }`}
+                                                        class="flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] p-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none"
                                                         type="button"
                                                         draggable="true"
                                                         aria-label={m.guild_folder()}
@@ -467,7 +469,7 @@
 
                                         {#if expandedFolders[item.folder.id]}
                                                 <div
-                                                        class="mt-2 flex flex-col items-center gap-2 rounded-2xl border border-[var(--stroke)] p-2"
+                                                        class="flex flex-col items-center gap-2 rounded-2xl border border-[var(--stroke)] p-2"
                                                         style:background="color-mix(in srgb, var(--panel-strong) 70%, transparent)"
                                                 >
                                                         <div


### PR DESCRIPTION
## Summary
- wrap the server folder trigger and its expanded content in a shared container so selection and drag outlines cover both
- streamline nested styles by relying on container gap spacing instead of a margin on the expanded panel

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0987237cc832288c9d3827e03e825