### PR TITLE
fix: center server icons in sidebar

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -377,7 +377,7 @@
                 ></div>
                 {#each displayItems as item, displayIndex (item.type === 'folder' ? `folder-${item.folder.id}` : `guild-${item.guildId}`)}
                         {#if item.type === 'guild'}
-                                <div class="group relative">
+                                <div class="group relative flex justify-center">
                                         <div
                                                 class={`absolute top-1/2 -left-2 w-1 -translate-y-1/2 rounded-full bg-[var(--brand)] transition-all ${
                                                         isGuildSelected(item.guildId)
@@ -483,7 +483,7 @@
                                                                 role="presentation"
                                                         ></div>
                                                         {#each item.guilds as nestedGuild, nestedIndex (nestedGuild.guildId)}
-                                                                <div class="group relative">
+                                                                <div class="group relative flex justify-center">
                                                                         <div
                                                                                 class={`absolute top-1/2 -left-2 w-1 -translate-y-1/2 rounded-full bg-[var(--brand)] transition-all ${
                                                                                         isGuildSelected(nestedGuild.guildId)


### PR DESCRIPTION
## Summary
- ensure guild buttons in the server bar remain horizontally centered by flexing the wrapper container
- apply the same centering to nested guild buttons inside expanded folders so indicators continue to align

## Testing
- npm run lint *(fails: existing Prettier formatting issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e09c6231e483229a80df713e4caaea