### PR TITLE
fix: guard guild layout reset until guilds synced

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -115,6 +115,7 @@ let saveDirty = false;
 let saveInFlight = false;
 
 let latestGuilds: DtoGuild[] = [];
+let hasSyncedGuildLayout = false;
 
 function structuredCloneSafe<T>(value: T): T {
         if (typeof structuredClone === 'function') {
@@ -541,6 +542,13 @@ export function createFolderWithGuilds(
 
 function syncLayoutWithGuilds() {
         const guildList = latestGuilds ?? [];
+
+        if (guildList.length > 0) {
+                hasSyncedGuildLayout = true;
+        } else if (!hasSyncedGuildLayout) {
+                return;
+        }
+
         mutateAppSettings((settings) => {
                 if (guildList.length === 0) {
                         if (settings.guildLayout.length === 0) return false;
@@ -600,6 +608,7 @@ function syncLayoutWithGuilds() {
 }
 
 async function loadSettingsFromApi() {
+        hasSyncedGuildLayout = false;
         if (!get(auth.isAuthenticated)) {
                 suppressSave = true;
                 appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
@@ -639,6 +648,7 @@ auth.token.subscribe((token) => {
         if (token) {
                 void loadSettingsFromApi();
         } else {
+                hasSyncedGuildLayout = false;
                 suppressSave = true;
                 appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
                 suppressSave = false;


### PR DESCRIPTION
## Summary
- add a hasSyncedGuildLayout flag to track whether guild data has populated the layout
- reset the sync guard when settings reload or the user logs out and skip clearing the layout until a populated guild list has been processed

## Testing
- npm run lint *(fails: existing Prettier formatting warnings across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e09f42abc48322bab1fa87e393a5a6