### PR TITLE
feat: persist selected guild preference

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -1,615 +1,627 @@
 <script lang="ts">
-        import type { DtoGuild } from '$lib/api';
-        import { m } from '$lib/paraglide/messages.js';
-        import { appSettings, createFolderWithGuilds, moveFolder, moveGuildToFolder, moveGuildToTop } from '$lib/stores/settings';
-        import { auth } from '$lib/stores/auth';
-        import { guildSettingsOpen, selectedGuildId } from '$lib/stores/appState';
-        import { contextMenu, copyToClipboard } from '$lib/stores/contextMenu';
-        import type { ContextMenuItem } from '$lib/stores/contextMenu';
-        import type { GuildFolderItem, GuildLayoutItem, GuildLayoutGuild } from '$lib/stores/settings';
-        import { Folder, Plus } from 'lucide-svelte';
-        import { onMount } from 'svelte';
-        import { selectGuild } from '$lib/utils/guildSelection';
-        import {
-                PERMISSION_MANAGE_CHANNELS,
-                PERMISSION_MANAGE_GUILD,
-                PERMISSION_MANAGE_ROLES,
-                hasAnyGuildPermission
-        } from '$lib/utils/permissions';
+	import type { DtoGuild } from '$lib/api';
+	import { m } from '$lib/paraglide/messages.js';
+	import {
+		appSettings,
+		createFolderWithGuilds,
+		moveFolder,
+		moveGuildToFolder,
+		moveGuildToTop
+	} from '$lib/stores/settings';
+	import { auth } from '$lib/stores/auth';
+	import { guildSettingsOpen, selectedGuildId } from '$lib/stores/appState';
+	import { contextMenu, copyToClipboard } from '$lib/stores/contextMenu';
+	import type { ContextMenuItem } from '$lib/stores/contextMenu';
+	import type { GuildFolderItem, GuildLayoutItem, GuildLayoutGuild } from '$lib/stores/settings';
+	import { Folder, Plus } from 'lucide-svelte';
+	import { onMount } from 'svelte';
+	import { persistSelectedGuildId, selectGuild } from '$lib/utils/guildSelection';
+	import {
+		PERMISSION_MANAGE_CHANNELS,
+		PERMISSION_MANAGE_GUILD,
+		PERMISSION_MANAGE_ROLES,
+		hasAnyGuildPermission
+	} from '$lib/utils/permissions';
 
-        const guilds = auth.guilds;
-        const me = auth.user;
+	const guilds = auth.guilds;
+	const me = auth.user;
 
-        type DisplayGuild = {
-                type: 'guild';
-                guild: DtoGuild;
-                guildId: string;
-                topIndex: number;
-                folderId: string | null;
-                folderIndex: number | null;
-                layout: GuildLayoutGuild | null;
-        };
+	type DisplayGuild = {
+		type: 'guild';
+		guild: DtoGuild;
+		guildId: string;
+		topIndex: number;
+		folderId: string | null;
+		folderIndex: number | null;
+		layout: GuildLayoutGuild | null;
+	};
 
-        type DisplayFolder = {
-                type: 'folder';
-                folder: GuildFolderItem;
-                topIndex: number;
-                guilds: DisplayGuild[];
-        };
+	type DisplayFolder = {
+		type: 'folder';
+		folder: GuildFolderItem;
+		topIndex: number;
+		guilds: DisplayGuild[];
+	};
 
-        type DisplayItem = DisplayGuild | DisplayFolder;
+	type DisplayItem = DisplayGuild | DisplayFolder;
 
-        type DragState =
-                | { type: 'guild'; guildId: string; fromFolderId: string | null }
-                | { type: 'folder'; folderId: string };
+	type DragState =
+		| { type: 'guild'; guildId: string; fromFolderId: string | null }
+		| { type: 'folder'; folderId: string };
 
-        let creating = $state(false);
-        let newGuildName = $state('');
-        let error: string | null = $state(null);
-        let leavingGuild = $state<{ id: string; name: string } | null>(null);
+	let creating = $state(false);
+	let newGuildName = $state('');
+	let error: string | null = $state(null);
+	let leavingGuild = $state<{ id: string; name: string } | null>(null);
 
-        let expandedFolders = $state<Record<string, boolean>>({});
-        let dragging: DragState | null = $state(null);
-        let topDropIndex: number | null = $state(null);
-        let folderDropTarget = $state<{ folderId: string; index: number } | null>(null);
-        let mergeTargetGuild: string | null = $state(null);
-        let displayItems = $state<DisplayItem[]>([]);
+	let expandedFolders = $state<Record<string, boolean>>({});
+	let dragging: DragState | null = $state(null);
+	let topDropIndex: number | null = $state(null);
+	let folderDropTarget = $state<{ folderId: string; index: number } | null>(null);
+	let mergeTargetGuild: string | null = $state(null);
+	let displayItems = $state<DisplayItem[]>([]);
 
-        $effect(() => {
-                const availableFolders = new Set(
-                        $appSettings.guildLayout
-                                .filter((item): item is GuildFolderItem => item.kind === 'folder')
-                                .map((folder) => folder.id)
-                );
-                const next: Record<string, boolean> = {};
-                for (const id of Object.keys(expandedFolders)) {
-                        if (availableFolders.has(id)) {
-                                next[id] = expandedFolders[id];
-                        }
-                }
+	$effect(() => {
+		const availableFolders = new Set(
+			$appSettings.guildLayout
+				.filter((item): item is GuildFolderItem => item.kind === 'folder')
+				.map((folder) => folder.id)
+		);
+		const next: Record<string, boolean> = {};
+		for (const id of Object.keys(expandedFolders)) {
+			if (availableFolders.has(id)) {
+				next[id] = expandedFolders[id];
+			}
+		}
 
-                const keys = new Set([...Object.keys(next), ...Object.keys(expandedFolders)]);
-                const changed = Array.from(keys).some((key) => expandedFolders[key] !== next[key]);
-                if (!changed) return;
+		const keys = new Set([...Object.keys(next), ...Object.keys(expandedFolders)]);
+		const changed = Array.from(keys).some((key) => expandedFolders[key] !== next[key]);
+		if (!changed) return;
 
-                expandedFolders = next;
-        });
+		expandedFolders = next;
+	});
 
-        function guildInitials(guild: DtoGuild | null | undefined): string {
-                const name = String((guild as any)?.name ?? '?');
-                return name.slice(0, 2).toUpperCase();
-        }
+	function guildInitials(guild: DtoGuild | null | undefined): string {
+		const name = String((guild as any)?.name ?? '?');
+		return name.slice(0, 2).toUpperCase();
+	}
 
-        function canAccessGuildSettings(guild: any): boolean {
-                return hasAnyGuildPermission(
-                        guild,
-                        $me?.id,
-                        PERMISSION_MANAGE_GUILD,
-                        PERMISSION_MANAGE_ROLES,
-                        PERMISSION_MANAGE_CHANNELS
-                );
-        }
+	function canAccessGuildSettings(guild: any): boolean {
+		return hasAnyGuildPermission(
+			guild,
+			$me?.id,
+			PERMISSION_MANAGE_GUILD,
+			PERMISSION_MANAGE_ROLES,
+			PERMISSION_MANAGE_CHANNELS
+		);
+	}
 
-        function openGuildSettings(gid: string) {
-                const targetGuild = $guilds.find((g) => String((g as any)?.id) === gid);
-                if (!canAccessGuildSettings(targetGuild)) return;
-                selectGuild(gid);
-                guildSettingsOpen.set(true);
-        }
+	function openGuildSettings(gid: string) {
+		const targetGuild = $guilds.find((g) => String((g as any)?.id) === gid);
+		if (!canAccessGuildSettings(targetGuild)) return;
+		selectGuild(gid);
+		guildSettingsOpen.set(true);
+	}
 
-        function buildDisplayItems(list: DtoGuild[], layout: GuildLayoutItem[]): DisplayItem[] {
-                const guildMap = new Map<string, DtoGuild>();
-                for (const guild of list) {
-                        const gid = String((guild as any)?.id ?? '');
-                        if (gid) guildMap.set(gid, guild);
-                }
+	function buildDisplayItems(list: DtoGuild[], layout: GuildLayoutItem[]): DisplayItem[] {
+		const guildMap = new Map<string, DtoGuild>();
+		for (const guild of list) {
+			const gid = String((guild as any)?.id ?? '');
+			if (gid) guildMap.set(gid, guild);
+		}
 
-                const seen = new Set<string>();
-                const items: DisplayItem[] = [];
-                let index = 0;
-                for (const item of layout) {
-                        if (item.kind === 'guild') {
-                                const guild = guildMap.get(item.guildId);
-                                if (!guild) {
-                                        index++;
-                                        continue;
-                                }
-                                seen.add(item.guildId);
-                                items.push({
-                                        type: 'guild',
-                                        guild,
-                                        guildId: item.guildId,
-                                        topIndex: index++,
-                                        folderId: null,
-                                        folderIndex: null,
-                                        layout: item
-                                });
-                        } else {
-                                const folderGuilds: DisplayGuild[] = [];
-                                item.guilds.forEach((entry, folderIndex) => {
-                                        const guild = guildMap.get(entry.guildId);
-                                        if (!guild) return;
-                                        seen.add(entry.guildId);
-                                        folderGuilds.push({
-                                                type: 'guild',
-                                                guild,
-                                                guildId: entry.guildId,
-                                                topIndex: index,
-                                                folderId: item.id,
-                                                folderIndex,
-                                                layout: entry
-                                        });
-                                });
-                                if (folderGuilds.length > 0) {
-                                        items.push({
-                                                type: 'folder',
-                                                folder: item,
-                                                topIndex: index++,
-                                                guilds: folderGuilds
-                                        });
-                                } else {
-                                        index++;
-                                }
-                        }
-                }
+		const seen = new Set<string>();
+		const items: DisplayItem[] = [];
+		let index = 0;
+		for (const item of layout) {
+			if (item.kind === 'guild') {
+				const guild = guildMap.get(item.guildId);
+				if (!guild) {
+					index++;
+					continue;
+				}
+				seen.add(item.guildId);
+				items.push({
+					type: 'guild',
+					guild,
+					guildId: item.guildId,
+					topIndex: index++,
+					folderId: null,
+					folderIndex: null,
+					layout: item
+				});
+			} else {
+				const folderGuilds: DisplayGuild[] = [];
+				item.guilds.forEach((entry, folderIndex) => {
+					const guild = guildMap.get(entry.guildId);
+					if (!guild) return;
+					seen.add(entry.guildId);
+					folderGuilds.push({
+						type: 'guild',
+						guild,
+						guildId: entry.guildId,
+						topIndex: index,
+						folderId: item.id,
+						folderIndex,
+						layout: entry
+					});
+				});
+				if (folderGuilds.length > 0) {
+					items.push({
+						type: 'folder',
+						folder: item,
+						topIndex: index++,
+						guilds: folderGuilds
+					});
+				} else {
+					index++;
+				}
+			}
+		}
 
-                for (const guild of list) {
-                        const gid = String((guild as any)?.id ?? '');
-                        if (!gid || seen.has(gid)) continue;
-                        items.push({
-                                type: 'guild',
-                                guild,
-                                guildId: gid,
-                                topIndex: index++,
-                                folderId: null,
-                                folderIndex: null,
-                                layout: null
-                        });
-                }
+		for (const guild of list) {
+			const gid = String((guild as any)?.id ?? '');
+			if (!gid || seen.has(gid)) continue;
+			items.push({
+				type: 'guild',
+				guild,
+				guildId: gid,
+				topIndex: index++,
+				folderId: null,
+				folderIndex: null,
+				layout: null
+			});
+		}
 
-                return items;
-        }
+		return items;
+	}
 
-        $effect(() => {
-                displayItems = buildDisplayItems($guilds ?? [], $appSettings.guildLayout);
-        });
+	$effect(() => {
+		displayItems = buildDisplayItems($guilds ?? [], $appSettings.guildLayout);
+	});
 
-        $effect(() => {
-                const selected = $selectedGuildId;
-                if (!selected) return;
-                for (const item of displayItems) {
-                        if (item.type !== 'folder') continue;
-                        if (!item.guilds.some((g) => g.guildId === selected)) continue;
+	$effect(() => {
+		const selected = $selectedGuildId;
+		if (!selected) return;
+		for (const item of displayItems) {
+			if (item.type !== 'folder') continue;
+			if (!item.guilds.some((g) => g.guildId === selected)) continue;
 
-                        if (!Object.prototype.hasOwnProperty.call(expandedFolders, item.folder.id)) {
-                                expandedFolders = {
-                                        ...expandedFolders,
-                                        [item.folder.id]: true
-                                };
-                        }
-                        break;
-                }
-        });
+			if (!Object.prototype.hasOwnProperty.call(expandedFolders, item.folder.id)) {
+				expandedFolders = {
+					...expandedFolders,
+					[item.folder.id]: true
+				};
+			}
+			break;
+		}
+	});
 
-        function startGuildDrag(event: DragEvent, guildId: string, fromFolderId: string | null) {
-                dragging = { type: 'guild', guildId, fromFolderId };
-                topDropIndex = null;
-                folderDropTarget = null;
-                mergeTargetGuild = null;
-                event.dataTransfer?.setData('text/plain', guildId);
-                event.dataTransfer?.setDragImage(new Image(), 0, 0);
-        }
+	function startGuildDrag(event: DragEvent, guildId: string, fromFolderId: string | null) {
+		dragging = { type: 'guild', guildId, fromFolderId };
+		topDropIndex = null;
+		folderDropTarget = null;
+		mergeTargetGuild = null;
+		event.dataTransfer?.setData('text/plain', guildId);
+		event.dataTransfer?.setDragImage(new Image(), 0, 0);
+	}
 
-        function startFolderDrag(event: DragEvent, folderId: string) {
-                dragging = { type: 'folder', folderId };
-                topDropIndex = null;
-                folderDropTarget = null;
-                mergeTargetGuild = null;
-                event.dataTransfer?.setData('text/plain', folderId);
-                event.dataTransfer?.setDragImage(new Image(), 0, 0);
-        }
+	function startFolderDrag(event: DragEvent, folderId: string) {
+		dragging = { type: 'folder', folderId };
+		topDropIndex = null;
+		folderDropTarget = null;
+		mergeTargetGuild = null;
+		event.dataTransfer?.setData('text/plain', folderId);
+		event.dataTransfer?.setDragImage(new Image(), 0, 0);
+	}
 
-        function endDrag() {
-                dragging = null;
-                topDropIndex = null;
-                folderDropTarget = null;
-                mergeTargetGuild = null;
-        }
+	function endDrag() {
+		dragging = null;
+		topDropIndex = null;
+		folderDropTarget = null;
+		mergeTargetGuild = null;
+	}
 
-        function onTopDragOver(event: DragEvent, index: number) {
-                if (!dragging) return;
-                event.preventDefault();
-                topDropIndex = index;
-                folderDropTarget = null;
-                mergeTargetGuild = null;
-        }
+	function onTopDragOver(event: DragEvent, index: number) {
+		if (!dragging) return;
+		event.preventDefault();
+		topDropIndex = index;
+		folderDropTarget = null;
+		mergeTargetGuild = null;
+	}
 
-        function onTopDrop(event: DragEvent, index: number) {
-                if (!dragging) return;
-                event.preventDefault();
-                if (dragging.type === 'guild') {
-                        moveGuildToTop(dragging.guildId, index);
-                } else {
-                        moveFolder(dragging.folderId, index);
-                }
-                endDrag();
-        }
+	function onTopDrop(event: DragEvent, index: number) {
+		if (!dragging) return;
+		event.preventDefault();
+		if (dragging.type === 'guild') {
+			moveGuildToTop(dragging.guildId, index);
+		} else {
+			moveFolder(dragging.folderId, index);
+		}
+		endDrag();
+	}
 
-        function onFolderDropZoneOver(event: DragEvent, folderId: string, index: number) {
-                if (!dragging || dragging.type !== 'guild') return;
-                event.preventDefault();
-                event.stopPropagation();
-                folderDropTarget = { folderId, index };
-                topDropIndex = null;
-                mergeTargetGuild = null;
-        }
+	function onFolderDropZoneOver(event: DragEvent, folderId: string, index: number) {
+		if (!dragging || dragging.type !== 'guild') return;
+		event.preventDefault();
+		event.stopPropagation();
+		folderDropTarget = { folderId, index };
+		topDropIndex = null;
+		mergeTargetGuild = null;
+	}
 
-        function onFolderDrop(event: DragEvent, folderId: string, index: number) {
-                if (!dragging || dragging.type !== 'guild') return;
-                event.preventDefault();
-                event.stopPropagation();
-                moveGuildToFolder(dragging.guildId, folderId, index);
-                expandedFolders = { ...expandedFolders, [folderId]: true };
-                endDrag();
-        }
+	function onFolderDrop(event: DragEvent, folderId: string, index: number) {
+		if (!dragging || dragging.type !== 'guild') return;
+		event.preventDefault();
+		event.stopPropagation();
+		moveGuildToFolder(dragging.guildId, folderId, index);
+		expandedFolders = { ...expandedFolders, [folderId]: true };
+		endDrag();
+	}
 
-        function onGuildMergeOver(event: DragEvent, guildId: string, topIndex: number, folderId: string | null) {
-                if (!dragging || dragging.type !== 'guild') return;
-                if (dragging.guildId === guildId) return;
-                if (folderId) return;
-                event.preventDefault();
-                event.stopPropagation();
-                mergeTargetGuild = guildId;
-                topDropIndex = null;
-                folderDropTarget = null;
-        }
+	function onGuildMergeOver(
+		event: DragEvent,
+		guildId: string,
+		topIndex: number,
+		folderId: string | null
+	) {
+		if (!dragging || dragging.type !== 'guild') return;
+		if (dragging.guildId === guildId) return;
+		if (folderId) return;
+		event.preventDefault();
+		event.stopPropagation();
+		mergeTargetGuild = guildId;
+		topDropIndex = null;
+		folderDropTarget = null;
+	}
 
-        function onGuildMergeDrop(event: DragEvent, guildId: string, topIndex: number) {
-                if (!dragging || dragging.type !== 'guild') return;
-                if (dragging.guildId === guildId) return;
-                event.preventDefault();
-                event.stopPropagation();
-                const folderId = createFolderWithGuilds(guildId, dragging.guildId, topIndex);
-                if (folderId) {
-                        expandedFolders = { ...expandedFolders, [folderId]: true };
-                }
-                endDrag();
-        }
+	function onGuildMergeDrop(event: DragEvent, guildId: string, topIndex: number) {
+		if (!dragging || dragging.type !== 'guild') return;
+		if (dragging.guildId === guildId) return;
+		event.preventDefault();
+		event.stopPropagation();
+		const folderId = createFolderWithGuilds(guildId, dragging.guildId, topIndex);
+		if (folderId) {
+			expandedFolders = { ...expandedFolders, [folderId]: true };
+		}
+		endDrag();
+	}
 
-        async function createGuild() {
-                if (!newGuildName.trim()) return;
-                try {
-                        await auth.api.guild.guildPost({ guildCreateGuildRequest: { name: newGuildName } });
-                        creating = false;
-                        newGuildName = '';
-                        error = null;
-                        await auth.loadGuilds();
-                } catch (e: any) {
-                        error = e?.response?.data?.message ?? e?.message ?? 'Failed to create guild';
-                }
-        }
+	async function createGuild() {
+		if (!newGuildName.trim()) return;
+		try {
+			await auth.api.guild.guildPost({ guildCreateGuildRequest: { name: newGuildName } });
+			creating = false;
+			newGuildName = '';
+			error = null;
+			await auth.loadGuilds();
+		} catch (e: any) {
+			error = e?.response?.data?.message ?? e?.message ?? 'Failed to create guild';
+		}
+	}
 
-        async function leaveGuildDirect(gid: string) {
-                try {
-                        await auth.api.user.userMeGuildsGuildIdDelete({ guildId: gid as any });
-                        await auth.loadGuilds();
-                } catch {
-                        /* ignore */
-                }
-        }
+	async function leaveGuildDirect(gid: string) {
+		try {
+			await auth.api.user.userMeGuildsGuildIdDelete({ guildId: gid as any });
+			await auth.loadGuilds();
+		} catch {
+			/* ignore */
+		}
+	}
 
-        async function confirmLeaveGuild() {
-                if (!leavingGuild) return;
-                const { id } = leavingGuild;
-                leavingGuild = null;
-                await leaveGuildDirect(id);
-                if ($selectedGuildId === id) {
-                        selectedGuildId.set(null);
-                }
-        }
+	async function confirmLeaveGuild() {
+		if (!leavingGuild) return;
+		const { id } = leavingGuild;
+		leavingGuild = null;
+		await leaveGuildDirect(id);
+		if ($selectedGuildId === id) {
+			selectedGuildId.set(null);
+			persistSelectedGuildId(null);
+		}
+	}
 
-        function openGuildMenu(event: MouseEvent, guild: DtoGuild) {
-                event.preventDefault();
-                const gid = String((guild as any)?.id ?? '');
-                const name = String((guild as any)?.name ?? 'Server');
-                const menuItems: ContextMenuItem[] = [
-                        { label: m.copy_server_id(), action: () => copyToClipboard(gid) }
-                ];
-                if (canAccessGuildSettings(guild)) {
-                        menuItems.push({
-                                label: m.server_settings(),
-                                action: () => openGuildSettings(gid)
-                        });
-                }
-                menuItems.push({
-                        label: m.leave_server(),
-                        action: () => {
-                                leavingGuild = { id: gid, name };
-                        },
-                        danger: true
-                });
-                contextMenu.openFromEvent(event, menuItems);
-        }
+	function openGuildMenu(event: MouseEvent, guild: DtoGuild) {
+		event.preventDefault();
+		const gid = String((guild as any)?.id ?? '');
+		const name = String((guild as any)?.name ?? 'Server');
+		const menuItems: ContextMenuItem[] = [
+			{ label: m.copy_server_id(), action: () => copyToClipboard(gid) }
+		];
+		if (canAccessGuildSettings(guild)) {
+			menuItems.push({
+				label: m.server_settings(),
+				action: () => openGuildSettings(gid)
+			});
+		}
+		menuItems.push({
+			label: m.leave_server(),
+			action: () => {
+				leavingGuild = { id: gid, name };
+			},
+			danger: true
+		});
+		contextMenu.openFromEvent(event, menuItems);
+	}
 
-        function isGuildSelected(guildId: string): boolean {
-                return $selectedGuildId === guildId;
-        }
+	function isGuildSelected(guildId: string): boolean {
+		return $selectedGuildId === guildId;
+	}
 
-        function selectGuildAndStore(id: string) {
-                selectGuild(id);
-                try {
-                        localStorage.setItem('lastGuild', id);
-                } catch {
-                        /* ignore */
-                }
-        }
+	function selectGuildAndPersist(id: string) {
+		selectGuild(id);
+	}
 
-        onMount(() => {
-                const unsubscribe = guilds.subscribe((arr) => {
-                        if (!$selectedGuildId && (arr?.length ?? 0) > 0) {
-                                let target = '';
-                                try {
-                                        const saved = localStorage.getItem('lastGuild');
-                                        if (saved) target = saved;
-                                } catch {
-                                        /* ignore */
-                                }
-                                const exists = target && arr.some((g: any) => String(g?.id) === target);
-                                const pick = exists ? target : String((arr[0] as any)?.id || '');
-                                if (pick) {
-                                        selectGuildAndStore(pick);
-                                }
-                        }
-                });
-                return () => unsubscribe();
-        });
+	onMount(() => {
+		const unsubscribe = guilds.subscribe((arr) => {
+			if (!$selectedGuildId && (arr?.length ?? 0) > 0) {
+				let target = $appSettings.selectedGuildId ?? '';
+				if (!target) {
+					try {
+						const saved = localStorage.getItem('lastGuild');
+						if (saved) target = saved;
+					} catch {
+						/* ignore */
+					}
+				}
+				const exists = target && arr.some((g: any) => String(g?.id) === target);
+				const pick = exists ? target : String((arr[0] as any)?.id || '');
+				if (pick) {
+					selectGuildAndPersist(pick);
+				}
+			}
+		});
+		return () => unsubscribe();
+	});
 </script>
 
-<div class="flex h-full w-[var(--col1)] flex-col items-center gap-2 overflow-hidden border-r border-[var(--stroke)] p-2">
-        <div class="scroll-area flex flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto pt-1">
-                <div
-                        class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
-                                topDropIndex === 0 ? 'opacity-80' : 'opacity-0'
-                        }`}
-                        ondragover={(event) => onTopDragOver(event, 0)}
-                        ondrop={(event) => onTopDrop(event, 0)}
-                        role="presentation"
-                ></div>
-                {#each displayItems as item, displayIndex (item.type === 'folder' ? `folder-${item.folder.id}` : `guild-${item.guildId}`)}
-                        {#if item.type === 'guild'}
-                                <div class="group relative flex justify-center">
-                                        <button
-                                                class={`flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
-                                                        isGuildSelected(item.guildId)
-                                                                ? 'shadow ring-2 ring-[var(--brand)] ring-inset'
-                                                                : ''
-                                                } ${
-                                                        mergeTargetGuild === item.guildId ? 'ring-2 ring-[var(--brand)]' : ''
-                                                }`}
-                                                title={item.guild.name}
-                                                aria-current={isGuildSelected(item.guildId) ? 'true' : 'false'}
-                                                draggable="true"
-                                                ondragstart={(event) => startGuildDrag(event, item.guildId, item.folderId)}
-                                                ondragend={endDrag}
-                                                ondragover={(event) => onGuildMergeOver(event, item.guildId, item.topIndex, item.folderId)}
-                                                ondrop={(event) => onGuildMergeDrop(event, item.guildId, item.topIndex)}
-                                                onclick={() => selectGuildAndStore(item.guildId)}
-                                                oncontextmenu={(event) => openGuildMenu(event, item.guild)}
-                                        >
-                                                <span class="font-bold">{guildInitials(item.guild)}</span>
-                                        </button>
-                                </div>
-                        {:else}
-                                {@const folderHasSelection = item.guilds.some((g) => isGuildSelected(g.guildId))}
-                                {@const folderIsDropTarget = folderDropTarget?.folderId === item.folder.id}
-                                <div class="group relative flex flex-col items-center gap-2 rounded-2xl">
-                                        <div class="relative">
-                                                <button
-                                                        class={`flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] p-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
-                                                                folderIsDropTarget
-                                                                        ? 'ring-2 ring-[var(--brand)]'
-                                                                        : folderHasSelection
-                                                                                ? 'ring-2 ring-[var(--brand)] ring-inset shadow'
-                                                                                : ''
-                                                        }`}
-                                                        type="button"
-                                                        draggable="true"
-                                                        aria-label={m.guild_folder()}
-                                                        ondragstart={(event) => startFolderDrag(event, item.folder.id)}
-                                                        ondragend={endDrag}
-                                                        ondragover={(event) => onFolderDropZoneOver(event, item.folder.id, item.guilds.length)}
-                                                        ondrop={(event) => onFolderDrop(event, item.folder.id, item.guilds.length)}
-                                                        onclick={() =>
-                                                                (expandedFolders = {
-                                                                        ...expandedFolders,
-                                                                        [item.folder.id]: !expandedFolders[item.folder.id]
-                                                                })
-                                                        }
-                                                >
-                                                        {#if expandedFolders[item.folder.id]}
-                                                                <Folder class="h-5 w-5" stroke-width={2} />
-                                                        {:else}
-                                                                <div class="grid h-full w-full grid-cols-2 grid-rows-2 gap-1">
-                                                                        {#each item.guilds.slice(0, 4) as guildPreview, idx (guildPreview.guildId)}
-                                                                                <div
-                                                                                        class={`flex items-center justify-center rounded-lg border border-[var(--stroke)] bg-[var(--panel)] text-xs font-semibold ${
-                                                                                                guildPreview.guildId === $selectedGuildId
-                                                                                                        ? 'border-[var(--brand)]'
-                                                                                                        : ''
-                                                                                        }`}
-                                                                                >
-                                                                                        {guildInitials(guildPreview.guild)}
-                                                                                </div>
-                                                                        {/each}
-                                                                        {#if item.guilds.length < 4}
-                                                                                {#each Array(4 - item.guilds.length) as _, fillerIdx (fillerIdx)}
-                                                                                        <div class="rounded-lg border border-dashed border-[var(--stroke)]"></div>
-                                                                                {/each}
-                                                                        {/if}
-                                                                </div>
-                                                        {/if}
-                                                </button>
-                                        </div>
+<div
+	class="flex h-full w-[var(--col1)] flex-col items-center gap-2 overflow-hidden border-r border-[var(--stroke)] p-2"
+>
+	<div class="scroll-area flex flex-1 flex-col gap-2 overflow-x-hidden overflow-y-auto pt-1">
+		<div
+			class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
+				topDropIndex === 0 ? 'opacity-80' : 'opacity-0'
+			}`}
+			ondragover={(event) => onTopDragOver(event, 0)}
+			ondrop={(event) => onTopDrop(event, 0)}
+			role="presentation"
+		></div>
+		{#each displayItems as item, displayIndex (item.type === 'folder' ? `folder-${item.folder.id}` : `guild-${item.guildId}`)}
+			{#if item.type === 'guild'}
+				<div class="group relative flex justify-center">
+					<button
+						class={`flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+							isGuildSelected(item.guildId) ? 'shadow ring-2 ring-[var(--brand)] ring-inset' : ''
+						} ${mergeTargetGuild === item.guildId ? 'ring-2 ring-[var(--brand)]' : ''}`}
+						title={item.guild.name}
+						aria-current={isGuildSelected(item.guildId) ? 'true' : 'false'}
+						draggable="true"
+						ondragstart={(event) => startGuildDrag(event, item.guildId, item.folderId)}
+						ondragend={endDrag}
+						ondragover={(event) =>
+							onGuildMergeOver(event, item.guildId, item.topIndex, item.folderId)}
+						ondrop={(event) => onGuildMergeDrop(event, item.guildId, item.topIndex)}
+						onclick={() => selectGuildAndPersist(item.guildId)}
+						oncontextmenu={(event) => openGuildMenu(event, item.guild)}
+					>
+						<span class="font-bold">{guildInitials(item.guild)}</span>
+					</button>
+				</div>
+			{:else}
+				{@const folderHasSelection = item.guilds.some((g) => isGuildSelected(g.guildId))}
+				{@const folderIsDropTarget = folderDropTarget?.folderId === item.folder.id}
+				<div class="group relative flex flex-col items-center gap-2 rounded-2xl">
+					<div class="relative">
+						<button
+							class={`flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] p-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+								folderIsDropTarget
+									? 'ring-2 ring-[var(--brand)]'
+									: folderHasSelection
+										? 'shadow ring-2 ring-[var(--brand)] ring-inset'
+										: ''
+							}`}
+							type="button"
+							draggable="true"
+							aria-label={m.guild_folder()}
+							ondragstart={(event) => startFolderDrag(event, item.folder.id)}
+							ondragend={endDrag}
+							ondragover={(event) =>
+								onFolderDropZoneOver(event, item.folder.id, item.guilds.length)}
+							ondrop={(event) => onFolderDrop(event, item.folder.id, item.guilds.length)}
+							onclick={() =>
+								(expandedFolders = {
+									...expandedFolders,
+									[item.folder.id]: !expandedFolders[item.folder.id]
+								})}
+						>
+							{#if expandedFolders[item.folder.id]}
+								<Folder class="h-5 w-5" stroke-width={2} />
+							{:else}
+								<div class="grid h-full w-full grid-cols-2 grid-rows-2 gap-1">
+									{#each item.guilds.slice(0, 4) as guildPreview, idx (guildPreview.guildId)}
+										<div
+											class={`flex items-center justify-center rounded-lg border border-[var(--stroke)] bg-[var(--panel)] text-xs font-semibold ${
+												guildPreview.guildId === $selectedGuildId ? 'border-[var(--brand)]' : ''
+											}`}
+										>
+											{guildInitials(guildPreview.guild)}
+										</div>
+									{/each}
+									{#if item.guilds.length < 4}
+										{#each Array(4 - item.guilds.length) as _, fillerIdx (fillerIdx)}
+											<div class="rounded-lg border border-dashed border-[var(--stroke)]"></div>
+										{/each}
+									{/if}
+								</div>
+							{/if}
+						</button>
+					</div>
 
-                                        {#if expandedFolders[item.folder.id]}
-                                                <div
-                                                        class="flex flex-col items-center gap-2 rounded-2xl border border-[var(--stroke)] p-2"
-                                                        style:background="color-mix(in srgb, var(--panel-strong) 70%, transparent)"
-                                                >
-                                                        <div
-                                                                class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
-                                                                        folderDropTarget?.folderId === item.folder.id && folderDropTarget.index === 0
-                                                                                ? 'opacity-80'
-                                                                                : 'opacity-0'
-                                                                }`}
-                                                                ondragover={(event) => onFolderDropZoneOver(event, item.folder.id, 0)}
-                                                                ondrop={(event) => onFolderDrop(event, item.folder.id, 0)}
-                                                                role="presentation"
-                                                        ></div>
-                                                        {#each item.guilds as nestedGuild, nestedIndex (nestedGuild.guildId)}
-                                                                <div class="group relative flex justify-center">
-                                                                        <button
-                                                                                class={`flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
-                                                                                        isGuildSelected(nestedGuild.guildId)
-                                                                                                ? 'shadow ring-2 ring-[var(--brand)] ring-inset'
-                                                                                                : ''
-                                                                                } ${
-                                                                                        folderDropTarget?.folderId === item.folder.id &&
-                                                                                        folderDropTarget.index === nestedIndex + 1
-                                                                                                ? 'ring-2 ring-[var(--brand)]'
-                                                                                                : ''
-                                                                                }`}
-                                                                                title={nestedGuild.guild.name}
-                                                                                aria-current={isGuildSelected(nestedGuild.guildId) ? 'true' : 'false'}
-                                                                                draggable="true"
-                                                                                ondragstart={(event) => startGuildDrag(event, nestedGuild.guildId, nestedGuild.folderId)}
-                                                                                ondragend={endDrag}
-                                                                                ondragover={(event) => onFolderDropZoneOver(event, item.folder.id, nestedIndex + 1)}
-                                                                                ondrop={(event) => onFolderDrop(event, item.folder.id, nestedIndex + 1)}
-                                                                                onclick={() => selectGuildAndStore(nestedGuild.guildId)}
-                                                                                oncontextmenu={(event) => openGuildMenu(event, nestedGuild.guild)}
-                                                                        >
-                                                                                <span class="font-bold">{guildInitials(nestedGuild.guild)}</span>
-                                                                        </button>
-                                                                </div>
-                                                        {/each}
-                                                </div>
-                                        {/if}
-                                </div>
-                        {/if}
-                        <div
-                                class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
-                                        topDropIndex === displayIndex + 1 ? 'opacity-80' : 'opacity-0'
-                                }`}
-                                ondragover={(event) => onTopDragOver(event, displayIndex + 1)}
-                                ondrop={(event) => onTopDrop(event, displayIndex + 1)}
-                                role="presentation"
-                        ></div>
-                {/each}
-        </div>
-        <div>
-                <button
-                        class="grid h-12 w-12 place-items-center rounded-xl border border-[var(--stroke)] hover:bg-[var(--panel)]"
-                        onclick={() => (creating = !creating)}
-                        title={m.new_server()}
-                        aria-label={m.new_server()}
-                >
-                        <Plus class="h-[18px] w-[18px]" stroke-width={2} />
-                </button>
-        </div>
+					{#if expandedFolders[item.folder.id]}
+						<div
+							class="flex flex-col items-center gap-2 rounded-2xl border border-[var(--stroke)] p-2"
+							style:background="color-mix(in srgb, var(--panel-strong) 70%, transparent)"
+						>
+							<div
+								class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
+									folderDropTarget?.folderId === item.folder.id && folderDropTarget.index === 0
+										? 'opacity-80'
+										: 'opacity-0'
+								}`}
+								ondragover={(event) => onFolderDropZoneOver(event, item.folder.id, 0)}
+								ondrop={(event) => onFolderDrop(event, item.folder.id, 0)}
+								role="presentation"
+							></div>
+							{#each item.guilds as nestedGuild, nestedIndex (nestedGuild.guildId)}
+								<div class="group relative flex justify-center">
+									<button
+										class={`flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+											isGuildSelected(nestedGuild.guildId)
+												? 'shadow ring-2 ring-[var(--brand)] ring-inset'
+												: ''
+										} ${
+											folderDropTarget?.folderId === item.folder.id &&
+											folderDropTarget.index === nestedIndex + 1
+												? 'ring-2 ring-[var(--brand)]'
+												: ''
+										}`}
+										title={nestedGuild.guild.name}
+										aria-current={isGuildSelected(nestedGuild.guildId) ? 'true' : 'false'}
+										draggable="true"
+										ondragstart={(event) =>
+											startGuildDrag(event, nestedGuild.guildId, nestedGuild.folderId)}
+										ondragend={endDrag}
+										ondragover={(event) =>
+											onFolderDropZoneOver(event, item.folder.id, nestedIndex + 1)}
+										ondrop={(event) => onFolderDrop(event, item.folder.id, nestedIndex + 1)}
+										onclick={() => selectGuildAndPersist(nestedGuild.guildId)}
+										oncontextmenu={(event) => openGuildMenu(event, nestedGuild.guild)}
+									>
+										<span class="font-bold">{guildInitials(nestedGuild.guild)}</span>
+									</button>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</div>
+			{/if}
+			<div
+				class={`h-2 w-full rounded bg-[var(--brand)] transition-opacity ${
+					topDropIndex === displayIndex + 1 ? 'opacity-80' : 'opacity-0'
+				}`}
+				ondragover={(event) => onTopDragOver(event, displayIndex + 1)}
+				ondrop={(event) => onTopDrop(event, displayIndex + 1)}
+				role="presentation"
+			></div>
+		{/each}
+	</div>
+	<div>
+		<button
+			class="grid h-12 w-12 place-items-center rounded-xl border border-[var(--stroke)] hover:bg-[var(--panel)]"
+			onclick={() => (creating = !creating)}
+			title={m.new_server()}
+			aria-label={m.new_server()}
+		>
+			<Plus class="h-[18px] w-[18px]" stroke-width={2} />
+		</button>
+	</div>
 
-        {#if creating}
-                <div
-                        class="fixed inset-0 z-50"
-                        role="dialog"
-                        tabindex="0"
-                        onpointerdown={() => (creating = false)}
-                        onkeydown={(event) => {
-                                if (event.key === 'Escape') creating = false;
-                                if (event.key === 'Enter') createGuild();
-                        }}
-                >
-                        <div class="absolute inset-0 bg-black/40"></div>
-                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
-                                <div class="relative">
-                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
-                                        <div
-                                                class="panel relative z-10 w-64 p-3"
-                                                role="document"
-                                                tabindex="-1"
-                                                onpointerdown={(event) => event.stopPropagation()}
-                                        >
-                                                <div class="mb-2 text-sm font-medium">{m.new_server()}</div>
-                                                {#if error}<div class="mb-2 text-sm text-red-500">{error}</div>{/if}
-                                                <input
-                                                        class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
-                                                        placeholder={m.server_name()}
-                                                        bind:value={newGuildName}
-                                                />
-                                                <div class="flex justify-end gap-2">
-                                                        <button
-                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
-                                                                onclick={() => (creating = false)}
-                                                        >
-                                                                {m.cancel()}
-                                                        </button>
-                                                        <button
-                                                                class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
-                                                                onclick={createGuild}
-                                                        >
-                                                                {m.create()}
-                                                        </button>
-                                                </div>
-                                        </div>
-                                </div>
-                        </div>
-                </div>
-        {/if}
+	{#if creating}
+		<div
+			class="fixed inset-0 z-50"
+			role="dialog"
+			tabindex="0"
+			onpointerdown={() => (creating = false)}
+			onkeydown={(event) => {
+				if (event.key === 'Escape') creating = false;
+				if (event.key === 'Enter') createGuild();
+			}}
+		>
+			<div class="absolute inset-0 bg-black/40"></div>
+			<div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+				<div class="relative">
+					<div
+						class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"
+					></div>
+					<div
+						class="panel relative z-10 w-64 p-3"
+						role="document"
+						tabindex="-1"
+						onpointerdown={(event) => event.stopPropagation()}
+					>
+						<div class="mb-2 text-sm font-medium">{m.new_server()}</div>
+						{#if error}<div class="mb-2 text-sm text-red-500">{error}</div>{/if}
+						<input
+							class="mb-2 w-full rounded-md border border-[var(--stroke)] bg-[var(--panel-strong)] px-3 py-2"
+							placeholder={m.server_name()}
+							bind:value={newGuildName}
+						/>
+						<div class="flex justify-end gap-2">
+							<button
+								class="rounded-md border border-[var(--stroke)] px-3 py-1"
+								onclick={() => (creating = false)}
+							>
+								{m.cancel()}
+							</button>
+							<button
+								class="rounded-md bg-[var(--brand)] px-3 py-1 text-[var(--bg)]"
+								onclick={createGuild}
+							>
+								{m.create()}
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
 
-        {#if leavingGuild}
-                <div
-                        class="fixed inset-0 z-50"
-                        role="dialog"
-                        tabindex="0"
-                        onpointerdown={() => (leavingGuild = null)}
-                        onkeydown={(event) => {
-                                if (event.key === 'Escape') leavingGuild = null;
-                                if (event.key === 'Enter') confirmLeaveGuild();
-                        }}
-                >
-                        <div class="absolute inset-0 bg-black/40"></div>
-                        <div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
-                                <div class="relative">
-                                        <div class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"></div>
-                                        <div
-                                                class="panel relative z-10 w-72 p-4"
-                                                role="document"
-                                                tabindex="-1"
-                                                onpointerdown={(event) => event.stopPropagation()}
-                                        >
-                                                <div class="mb-2 text-base font-semibold">
-                                                        {m.leave_server_confirm_title({ server: leavingGuild.name })}
-                                                </div>
-                                                <p class="mb-4 text-sm text-[var(--muted)]">
-                                                        {m.leave_server_confirm_description({ server: leavingGuild.name })}
-                                                </p>
-                                                <div class="flex justify-end gap-2">
-                                                        <button
-                                                                class="rounded-md border border-[var(--stroke)] px-3 py-1"
-                                                                onclick={() => (leavingGuild = null)}
-                                                        >
-                                                                {m.cancel()}
-                                                        </button>
-                                                        <button
-                                                                class="rounded-md bg-[var(--danger)] px-3 py-1 text-[var(--bg)]"
-                                                                onclick={confirmLeaveGuild}
-                                                        >
-                                                                {m.leave_server()}
-                                                        </button>
-                                                </div>
-                                        </div>
-                                </div>
-                        </div>
-                </div>
-        {/if}
+	{#if leavingGuild}
+		<div
+			class="fixed inset-0 z-50"
+			role="dialog"
+			tabindex="0"
+			onpointerdown={() => (leavingGuild = null)}
+			onkeydown={(event) => {
+				if (event.key === 'Escape') leavingGuild = null;
+				if (event.key === 'Enter') confirmLeaveGuild();
+			}}
+		>
+			<div class="absolute inset-0 bg-black/40"></div>
+			<div class="absolute top-1/2 left-1/2 z-10 -translate-x-1/2 -translate-y-1/2">
+				<div class="relative">
+					<div
+						class="pointer-events-none absolute inset-0 z-0 rounded-lg bg-[var(--panel)]/30 backdrop-blur-sm"
+					></div>
+					<div
+						class="panel relative z-10 w-72 p-4"
+						role="document"
+						tabindex="-1"
+						onpointerdown={(event) => event.stopPropagation()}
+					>
+						<div class="mb-2 text-base font-semibold">
+							{m.leave_server_confirm_title({ server: leavingGuild.name })}
+						</div>
+						<p class="mb-4 text-sm text-[var(--muted)]">
+							{m.leave_server_confirm_description({ server: leavingGuild.name })}
+						</p>
+						<div class="flex justify-end gap-2">
+							<button
+								class="rounded-md border border-[var(--stroke)] px-3 py-1"
+								onclick={() => (leavingGuild = null)}
+							>
+								{m.cancel()}
+							</button>
+							<button
+								class="rounded-md bg-[var(--danger)] px-3 py-1 text-[var(--bg)]"
+								onclick={confirmLeaveGuild}
+							>
+								{m.leave_server()}
+							</button>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	{/if}
 </div>

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -1,14 +1,15 @@
 import { browser } from '$app/environment';
 import {
-        type DtoGuild,
-        type ModelGuildChannelReadState,
-        type ModelUserSettingsData,
-        type ModelUserSettingsGuildFolders,
-        type ModelUserSettingsGuilds,
-        type ModelUserSettingsNotifications
+	type DtoGuild,
+	type ModelGuildChannelReadState,
+	type ModelUserSettingsData,
+	type ModelUserSettingsGuildFolders,
+	type ModelUserSettingsGuilds,
+	type ModelUserSettingsNotifications
 } from '$lib/api';
 import { setLocale } from '$lib/paraglide/runtime';
 import { auth } from '$lib/stores/auth';
+import { selectedGuildId } from '$lib/stores/appState';
 import { derived, get, writable } from 'svelte/store';
 
 export type Theme = 'light' | 'dark' | 'system';
@@ -17,88 +18,100 @@ const supportedLocales = ['en', 'ru', 'de', 'fr'] as const;
 export type Locale = (typeof supportedLocales)[number];
 
 function isLocale(value: unknown): value is Locale {
-        return typeof value === 'string' && supportedLocales.includes(value as Locale);
+	return typeof value === 'string' && supportedLocales.includes(value as Locale);
 }
 
 const initialTheme: Theme = browser
-        ? ((localStorage.getItem('theme') as Theme) || 'system')
-        : 'system';
+	? (localStorage.getItem('theme') as Theme) || 'system'
+	: 'system';
 
 const storedLocale = browser ? localStorage.getItem('locale') : null;
 const initialLocale: Locale = storedLocale && isLocale(storedLocale) ? storedLocale : 'en';
 
+const initialSelectedGuildId = browser
+	? (() => {
+			try {
+				return localStorage.getItem('lastGuild');
+			} catch {
+				return null;
+			}
+		})()
+	: null;
+
 function applyTheme(theme: Theme) {
-        if (!browser) return;
-        const mode =
-                theme === 'system'
-                        ? window.matchMedia('(prefers-color-scheme: dark)').matches
-                                ? 'dark'
-                                : 'light'
-                        : theme;
-        document.documentElement.setAttribute('data-theme', mode);
+	if (!browser) return;
+	const mode =
+		theme === 'system'
+			? window.matchMedia('(prefers-color-scheme: dark)').matches
+				? 'dark'
+				: 'light'
+			: theme;
+	document.documentElement.setAttribute('data-theme', mode);
 }
 
 export const theme = writable<Theme>(initialTheme);
 
 theme.subscribe((value) => {
-        if (browser) {
-                applyTheme(value);
-                try {
-                        localStorage.setItem('theme', value);
-                } catch {
-                        /* ignore */
-                }
-        }
+	if (browser) {
+		applyTheme(value);
+		try {
+			localStorage.setItem('theme', value);
+		} catch {
+			/* ignore */
+		}
+	}
 });
 
 setLocale(initialLocale);
 export const locale = writable<Locale>(initialLocale);
 
 locale.subscribe((value) => {
-        setLocale(value);
-        if (browser) {
-                try {
-                        localStorage.setItem('locale', value);
-                } catch {
-                        /* ignore */
-                }
-        }
+	setLocale(value);
+	if (browser) {
+		try {
+			localStorage.setItem('locale', value);
+		} catch {
+			/* ignore */
+		}
+	}
 });
 
 export interface GuildLayoutGuild {
-        guildId: string;
-        notifications?: ModelUserSettingsNotifications;
-        readStates?: ModelGuildChannelReadState[];
+	guildId: string;
+	notifications?: ModelUserSettingsNotifications;
+	readStates?: ModelGuildChannelReadState[];
 }
 
 export interface GuildTopLevelItem extends GuildLayoutGuild {
-        kind: 'guild';
+	kind: 'guild';
 }
 
 export interface GuildFolderItem {
-        kind: 'folder';
-        id: string;
-        name: string | null;
-        color: number | null;
-        guilds: GuildLayoutGuild[];
+	kind: 'folder';
+	id: string;
+	name: string | null;
+	color: number | null;
+	guilds: GuildLayoutGuild[];
 }
 
 export type GuildLayoutItem = GuildTopLevelItem | GuildFolderItem;
 
 export interface AppSettings {
-        language: Locale;
-        theme: Theme;
-        chatFontScale: number;
-        chatSpacing: number;
-        guildLayout: GuildLayoutItem[];
+	language: Locale;
+	theme: Theme;
+	chatFontScale: number;
+	chatSpacing: number;
+	guildLayout: GuildLayoutItem[];
+	selectedGuildId: string | null;
 }
 
 const defaultSettings: AppSettings = {
-        language: initialLocale,
-        theme: initialTheme,
-        chatFontScale: 1,
-        chatSpacing: 1,
-        guildLayout: []
+	language: initialLocale,
+	theme: initialTheme,
+	chatFontScale: 1,
+	chatSpacing: 1,
+	guildLayout: [],
+	selectedGuildId: initialSelectedGuildId
 };
 
 export const appSettings = writable<AppSettings>(defaultSettings);
@@ -115,574 +128,611 @@ let saveDirty = false;
 let saveInFlight = false;
 
 let latestGuilds: DtoGuild[] = [];
+let guildsHydrated = false;
 let hasSyncedGuildLayout = false;
 
 function structuredCloneSafe<T>(value: T): T {
-        if (typeof structuredClone === 'function') {
-                return structuredClone(value);
-        }
-        return JSON.parse(JSON.stringify(value)) as T;
+	if (typeof structuredClone === 'function') {
+		return structuredClone(value);
+	}
+	return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function cloneSettings(settings: AppSettings): AppSettings {
-        return {
-                language: settings.language,
-                theme: settings.theme,
-                chatFontScale: settings.chatFontScale,
-                chatSpacing: settings.chatSpacing,
-                guildLayout: settings.guildLayout.map((item) => {
-                        if (item.kind === 'guild') {
-                                return {
-                                        kind: 'guild',
-                                        guildId: item.guildId,
-                                        notifications: item.notifications
-                                                ? structuredCloneSafe(item.notifications)
-                                                : undefined,
-                                        readStates: item.readStates ? structuredCloneSafe(item.readStates) : undefined
-                                } satisfies GuildTopLevelItem;
-                        }
-                        return {
-                                kind: 'folder',
-                                id: item.id,
-                                name: item.name,
-                                color: item.color,
-                                guilds: item.guilds.map((guild) => ({
-                                        guildId: guild.guildId,
-                                        notifications: guild.notifications
-                                                ? structuredCloneSafe(guild.notifications)
-                                                : undefined,
-                                        readStates: guild.readStates
-                                                ? structuredCloneSafe(guild.readStates)
-                                                : undefined
-                                }))
-                        } satisfies GuildFolderItem;
-                })
-        };
+	return {
+		language: settings.language,
+		theme: settings.theme,
+		chatFontScale: settings.chatFontScale,
+		chatSpacing: settings.chatSpacing,
+		selectedGuildId: settings.selectedGuildId,
+		guildLayout: settings.guildLayout.map((item) => {
+			if (item.kind === 'guild') {
+				return {
+					kind: 'guild',
+					guildId: item.guildId,
+					notifications: item.notifications ? structuredCloneSafe(item.notifications) : undefined,
+					readStates: item.readStates ? structuredCloneSafe(item.readStates) : undefined
+				} satisfies GuildTopLevelItem;
+			}
+			return {
+				kind: 'folder',
+				id: item.id,
+				name: item.name,
+				color: item.color,
+				guilds: item.guilds.map((guild) => ({
+					guildId: guild.guildId,
+					notifications: guild.notifications ? structuredCloneSafe(guild.notifications) : undefined,
+					readStates: guild.readStates ? structuredCloneSafe(guild.readStates) : undefined
+				}))
+			} satisfies GuildFolderItem;
+		})
+	};
 }
 
 function toSnowflakeString(value: unknown): string | null {
-        if (value == null) return null;
-        try {
-                if (typeof value === 'string') return value;
-                if (typeof value === 'number' || typeof value === 'bigint') return BigInt(value).toString();
-        } catch {
-                /* ignore */
-        }
-        try {
-                return String(value);
-        } catch {
-                return null;
-        }
+	if (value == null) return null;
+	try {
+		if (typeof value === 'string') return value;
+		if (typeof value === 'number' || typeof value === 'bigint') return BigInt(value).toString();
+	} catch {
+		/* ignore */
+	}
+	try {
+		return String(value);
+	} catch {
+		return null;
+	}
 }
 
 function toApiSnowflake(value: string): any {
-        try {
-                return BigInt(value) as any;
-        } catch {
-                return value as any;
-        }
+	try {
+		return BigInt(value) as any;
+	} catch {
+		return value as any;
+	}
 }
 
 function normalizeFolderArray(
-        input: ModelUserSettingsGuildFolders | ModelUserSettingsGuildFolders[] | undefined
+	input: ModelUserSettingsGuildFolders | ModelUserSettingsGuildFolders[] | undefined
 ): ModelUserSettingsGuildFolders[] {
-        if (!input) return [];
-        return Array.isArray(input) ? input : [input];
+	if (!input) return [];
+	return Array.isArray(input) ? input : [input];
 }
 
 function convertFromApi(data?: ModelUserSettingsData | null): AppSettings {
-        if (!data) return cloneSettings(defaultSettings);
+	if (!data) return cloneSettings(defaultSettings);
 
-        const appearance = data.appearance ?? {};
-        const themeValue = (appearance.color_scheme as Theme | undefined) ?? defaultSettings.theme;
-        const languageValue = isLocale(data.language) ? (data.language as Locale) : defaultSettings.language;
-        const chatFontScale = typeof appearance.chat_font_scale === 'number'
-                ? appearance.chat_font_scale
-                : defaultSettings.chatFontScale;
-        const chatSpacing = typeof appearance.chat_spacing === 'number'
-                ? appearance.chat_spacing
-                : defaultSettings.chatSpacing;
+	const appearance = data.appearance ?? {};
+	const themeValue = (appearance.color_scheme as Theme | undefined) ?? defaultSettings.theme;
+	const languageValue = isLocale(data.language)
+		? (data.language as Locale)
+		: defaultSettings.language;
+	const chatFontScale =
+		typeof appearance.chat_font_scale === 'number'
+			? appearance.chat_font_scale
+			: defaultSettings.chatFontScale;
+	const chatSpacing =
+		typeof appearance.chat_spacing === 'number'
+			? appearance.chat_spacing
+			: defaultSettings.chatSpacing;
 
-        const folderEntries = normalizeFolderArray(data.guild_folders).map((folder, idx) => {
-                const id = generateFolderId();
-                const guildIds = Array.isArray(folder.guilds)
-                        ? folder.guilds.map((gid) => toSnowflakeString(gid)).filter((gid): gid is string => Boolean(gid))
-                        : [];
-                return {
-                        folder: {
-                                kind: 'folder' as const,
-                                id,
-                                name: folder.name ?? null,
-                                color: typeof folder.color === 'number' ? folder.color : null,
-                                guilds: [] as GuildLayoutGuild[]
-                        },
-                        guildIds,
-                        position: typeof folder.position === 'number' ? folder.position : idx
-                };
-        });
+	const folderEntries = normalizeFolderArray(data.guild_folders).map((folder, idx) => {
+		const id = generateFolderId();
+		const guildIds = Array.isArray(folder.guilds)
+			? folder.guilds
+					.map((gid) => toSnowflakeString(gid))
+					.filter((gid): gid is string => Boolean(gid))
+			: [];
+		return {
+			folder: {
+				kind: 'folder' as const,
+				id,
+				name: folder.name ?? null,
+				color: typeof folder.color === 'number' ? folder.color : null,
+				guilds: [] as GuildLayoutGuild[]
+			},
+			guildIds,
+			position: typeof folder.position === 'number' ? folder.position : idx
+		};
+	});
 
-        const folderByGuild = new Map<string, (typeof folderEntries)[number]>();
-        for (const entry of folderEntries) {
-                for (const gid of entry.guildIds) {
-                        folderByGuild.set(gid, entry);
-                }
-        }
+	const folderByGuild = new Map<string, (typeof folderEntries)[number]>();
+	for (const entry of folderEntries) {
+		for (const gid of entry.guildIds) {
+			folderByGuild.set(gid, entry);
+		}
+	}
 
-        const layoutWithPositions: Array<{ item: GuildLayoutItem; position: number }> = [];
-        const guildsArray = Array.isArray(data.guilds) ? data.guilds : [];
+	const layoutWithPositions: Array<{ item: GuildLayoutItem; position: number }> = [];
+	const guildsArray = Array.isArray(data.guilds) ? data.guilds : [];
 
-        for (const guildSetting of guildsArray) {
-                const guildId = toSnowflakeString(guildSetting.guild_id);
-                if (!guildId) continue;
-                const baseGuild: GuildLayoutGuild = {
-                        guildId,
-                        notifications: guildSetting.notifications
-                                ? structuredCloneSafe(guildSetting.notifications)
-                                : undefined,
-                        readStates: guildSetting.read_states
-                                ? structuredCloneSafe(guildSetting.read_states)
-                                : undefined
-                };
+	for (const guildSetting of guildsArray) {
+		const guildId = toSnowflakeString(guildSetting.guild_id);
+		if (!guildId) continue;
+		const baseGuild: GuildLayoutGuild = {
+			guildId,
+			notifications: guildSetting.notifications
+				? structuredCloneSafe(guildSetting.notifications)
+				: undefined,
+			readStates: guildSetting.read_states
+				? structuredCloneSafe(guildSetting.read_states)
+				: undefined
+		};
 
-                const folderEntry = folderByGuild.get(guildId);
-                if (folderEntry) {
-                        const position = typeof guildSetting.position === 'number' ? guildSetting.position : 0;
-                        (baseGuild as any).__position = position;
-                        folderEntry.folder.guilds.push(baseGuild);
-                } else {
-                        const position =
-                                typeof guildSetting.position === 'number'
-                                        ? guildSetting.position
-                                        : layoutWithPositions.length;
-                        layoutWithPositions.push({ item: { kind: 'guild', ...baseGuild }, position });
-                }
-        }
+		const folderEntry = folderByGuild.get(guildId);
+		if (folderEntry) {
+			const position = typeof guildSetting.position === 'number' ? guildSetting.position : 0;
+			(baseGuild as any).__position = position;
+			folderEntry.folder.guilds.push(baseGuild);
+		} else {
+			const position =
+				typeof guildSetting.position === 'number'
+					? guildSetting.position
+					: layoutWithPositions.length;
+			layoutWithPositions.push({ item: { kind: 'guild', ...baseGuild }, position });
+		}
+	}
 
-        for (const entry of folderEntries) {
-                if (entry.guildIds.length > 0 && entry.folder.guilds.length === 0) {
-                        for (const gid of entry.guildIds) {
-                                entry.folder.guilds.push({ guildId: gid } as GuildLayoutGuild);
-                        }
-                }
-                entry.folder.guilds.sort((a: GuildLayoutGuild & { __position?: number }, b: GuildLayoutGuild & { __position?: number }) => {
-                        const pa = typeof a.__position === 'number' ? a.__position : 0;
-                        const pb = typeof b.__position === 'number' ? b.__position : 0;
-                        return pa - pb;
-                });
-                entry.folder.guilds.forEach((guild) => {
-                        if ('__position' in guild) delete (guild as any).__position;
-                });
-                layoutWithPositions.push({ item: entry.folder, position: entry.position });
-        }
+	for (const entry of folderEntries) {
+		if (entry.guildIds.length > 0 && entry.folder.guilds.length === 0) {
+			for (const gid of entry.guildIds) {
+				entry.folder.guilds.push({ guildId: gid } as GuildLayoutGuild);
+			}
+		}
+		entry.folder.guilds.sort(
+			(
+				a: GuildLayoutGuild & { __position?: number },
+				b: GuildLayoutGuild & { __position?: number }
+			) => {
+				const pa = typeof a.__position === 'number' ? a.__position : 0;
+				const pb = typeof b.__position === 'number' ? b.__position : 0;
+				return pa - pb;
+			}
+		);
+		entry.folder.guilds.forEach((guild) => {
+			if ('__position' in guild) delete (guild as any).__position;
+		});
+		layoutWithPositions.push({ item: entry.folder, position: entry.position });
+	}
 
-        layoutWithPositions.sort((a, b) => a.position - b.position);
+	layoutWithPositions.sort((a, b) => a.position - b.position);
 
-        return {
-                language: languageValue,
-                theme: themeValue,
-                chatFontScale,
-                chatSpacing,
-                guildLayout: layoutWithPositions.map((entry) => entry.item)
-        };
+	return {
+		language: languageValue,
+		theme: themeValue,
+		chatFontScale,
+		chatSpacing,
+		guildLayout: layoutWithPositions.map((entry) => entry.item),
+		selectedGuildId: toSnowflakeString(data.selected_guild)
+	};
 }
 
 function convertToApi(settings: AppSettings): ModelUserSettingsData {
-        const payloadGuilds: ModelUserSettingsGuilds[] = [];
-        const payloadFolders: ModelUserSettingsGuildFolders[] = [];
+	const payloadGuilds: ModelUserSettingsGuilds[] = [];
+	const payloadFolders: ModelUserSettingsGuildFolders[] = [];
 
-        let topPosition = 0;
-        for (const item of settings.guildLayout) {
-                if (item.kind === 'guild') {
-                        payloadGuilds.push({
-                                guild_id: toApiSnowflake(item.guildId),
-                                position: topPosition,
-                                notifications: item.notifications
-                                        ? structuredCloneSafe(item.notifications)
-                                        : undefined,
-                                read_states: item.readStates
-                                        ? structuredCloneSafe(item.readStates)
-                                        : undefined
-                        });
-                        topPosition++;
-                } else {
-                        payloadFolders.push({
-                                name: item.name ?? undefined,
-                                color: item.color ?? undefined,
-                                guilds: item.guilds.map((guild) => toApiSnowflake(guild.guildId)),
-                                position: topPosition
-                        });
-                        let inner = 0;
-                        for (const guild of item.guilds) {
-                                payloadGuilds.push({
-                                        guild_id: toApiSnowflake(guild.guildId),
-                                        position: inner,
-                                        notifications: guild.notifications
-                                                ? structuredCloneSafe(guild.notifications)
-                                                : undefined,
-                                        read_states: guild.readStates
-                                                ? structuredCloneSafe(guild.readStates)
-                                                : undefined
-                                });
-                                inner++;
-                        }
-                        topPosition++;
-                }
-        }
+	let topPosition = 0;
+	for (const item of settings.guildLayout) {
+		if (item.kind === 'guild') {
+			payloadGuilds.push({
+				guild_id: toApiSnowflake(item.guildId),
+				position: topPosition,
+				notifications: item.notifications ? structuredCloneSafe(item.notifications) : undefined,
+				read_states: item.readStates ? structuredCloneSafe(item.readStates) : undefined
+			});
+			topPosition++;
+		} else {
+			payloadFolders.push({
+				name: item.name ?? undefined,
+				color: item.color ?? undefined,
+				guilds: item.guilds.map((guild) => toApiSnowflake(guild.guildId)),
+				position: topPosition
+			});
+			let inner = 0;
+			for (const guild of item.guilds) {
+				payloadGuilds.push({
+					guild_id: toApiSnowflake(guild.guildId),
+					position: inner,
+					notifications: guild.notifications ? structuredCloneSafe(guild.notifications) : undefined,
+					read_states: guild.readStates ? structuredCloneSafe(guild.readStates) : undefined
+				});
+				inner++;
+			}
+			topPosition++;
+		}
+	}
 
-        return {
-                language: settings.language,
-                appearance: {
-                        color_scheme: settings.theme,
-                        chat_font_scale: settings.chatFontScale,
-                        chat_spacing: settings.chatSpacing
-                },
-                guilds: payloadGuilds,
-                guild_folders: payloadFolders as unknown as ModelUserSettingsGuildFolders
-        };
+	return {
+		language: settings.language,
+		appearance: {
+			color_scheme: settings.theme,
+			chat_font_scale: settings.chatFontScale,
+			chat_spacing: settings.chatSpacing
+		},
+		guilds: payloadGuilds,
+		guild_folders: payloadFolders as unknown as ModelUserSettingsGuildFolders,
+		selected_guild: settings.selectedGuildId ? toApiSnowflake(settings.selectedGuildId) : undefined
+	};
+}
+
+function persistSelectedGuildFallback(value: string | null) {
+	if (!browser) return;
+	try {
+		if (value) {
+			localStorage.setItem('lastGuild', value);
+		} else {
+			localStorage.removeItem('lastGuild');
+		}
+	} catch {
+		/* ignore */
+	}
+}
+
+function applySelectedGuildFromSettings(clearInvalid: boolean) {
+	const stored = get(appSettings).selectedGuildId;
+	if (!stored) {
+		selectedGuildId.set(null);
+		persistSelectedGuildFallback(null);
+		return;
+	}
+
+	const exists = latestGuilds.some((guild) => toSnowflakeString((guild as any)?.id) === stored);
+	if (exists) {
+		selectedGuildId.set(stored);
+		persistSelectedGuildFallback(stored);
+	} else if (clearInvalid) {
+		if (!guildsHydrated) return;
+		selectedGuildId.set(null);
+		persistSelectedGuildFallback(null);
+		mutateAppSettings((settings) => {
+			if (settings.selectedGuildId === null) return false;
+			settings.selectedGuildId = null;
+			return true;
+		});
+	}
 }
 
 function scheduleSave() {
-        if (suppressSave) return;
-        if (!get(settingsReady)) return;
-        if (!get(auth.isAuthenticated)) return;
-        saveDirty = true;
-        if (saveTimeout) clearTimeout(saveTimeout);
-        saveTimeout = setTimeout(() => {
-                saveTimeout = null;
-                void persistSettings();
-        }, 400);
+	if (suppressSave) return;
+	if (!get(settingsReady)) return;
+	if (!get(auth.isAuthenticated)) return;
+	saveDirty = true;
+	if (saveTimeout) clearTimeout(saveTimeout);
+	saveTimeout = setTimeout(() => {
+		saveTimeout = null;
+		void persistSettings();
+	}, 400);
 }
 
 async function persistSettings() {
-        if (!saveDirty) return;
-        if (!get(auth.isAuthenticated)) {
-                saveDirty = false;
-                return;
-        }
-        if (saveInFlight) return;
-        saveInFlight = true;
-        saveDirty = false;
-        settingsSaving.set(true);
-        try {
-                const payload = convertToApi(get(appSettings));
-                await auth.api.user.userMeSettingsPost({
-                        modelUserSettingsData: payload
-                });
-        } catch (error) {
-                console.error('Failed to save settings', error);
-                saveDirty = true;
-        } finally {
-                saveInFlight = false;
-                settingsSaving.set(false);
-                if (saveDirty && !saveTimeout) {
-                        saveTimeout = setTimeout(() => {
-                                saveTimeout = null;
-                                void persistSettings();
-                        }, 400);
-                }
-        }
+	if (!saveDirty) return;
+	if (!get(auth.isAuthenticated)) {
+		saveDirty = false;
+		return;
+	}
+	if (saveInFlight) return;
+	saveInFlight = true;
+	saveDirty = false;
+	settingsSaving.set(true);
+	try {
+		const payload = convertToApi(get(appSettings));
+		await auth.api.user.userMeSettingsPost({
+			modelUserSettingsData: payload
+		});
+	} catch (error) {
+		console.error('Failed to save settings', error);
+		saveDirty = true;
+	} finally {
+		saveInFlight = false;
+		settingsSaving.set(false);
+		if (saveDirty && !saveTimeout) {
+			saveTimeout = setTimeout(() => {
+				saveTimeout = null;
+				void persistSettings();
+			}, 400);
+		}
+	}
 }
 
 type SettingsMutator = (settings: AppSettings) => boolean;
 
 export function mutateAppSettings(mutator: SettingsMutator) {
-        appSettings.update((current) => {
-                const cloned = cloneSettings(current);
-                const changed = mutator(cloned);
-                if (!changed) return current;
-                scheduleSave();
-                return cloned;
-        });
+	appSettings.update((current) => {
+		const cloned = cloneSettings(current);
+		const changed = mutator(cloned);
+		if (!changed) return current;
+		scheduleSave();
+		return cloned;
+	});
 }
 
 function generateFolderId(): string {
-        return `folder-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+	return `folder-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function clamp(value: number, min: number, max: number): number {
-        return Math.max(min, Math.min(max, value));
+	return Math.max(min, Math.min(max, value));
 }
 
 function detachGuild(
-        layout: GuildLayoutItem[],
-        guildId: string
+	layout: GuildLayoutItem[],
+	guildId: string
 ): { guild: GuildLayoutGuild | null; removedIndex: number | null } {
-        for (let i = 0; i < layout.length; i++) {
-                const item = layout[i];
-                if (item.kind === 'guild') {
-                        if (item.guildId === guildId) {
-                                layout.splice(i, 1);
-                                return {
-                                        guild: {
-                                                guildId: item.guildId,
-                                                notifications: item.notifications,
-                                                readStates: item.readStates
-                                        },
-                                        removedIndex: i
-                                };
-                        }
-                        continue;
-                }
-                const idx = item.guilds.findIndex((guild) => guild.guildId === guildId);
-                if (idx === -1) continue;
-                const [removed] = item.guilds.splice(idx, 1);
-                if (item.guilds.length === 0) {
-                        layout.splice(i, 1);
-                        return { guild: removed, removedIndex: i };
-                }
-                if (item.guilds.length === 1) {
-                        const [remaining] = item.guilds;
-                        layout.splice(i, 1, { kind: 'guild', ...remaining });
-                        return { guild: removed, removedIndex: null };
-                }
-                return { guild: removed, removedIndex: null };
-        }
-        return { guild: null, removedIndex: null };
+	for (let i = 0; i < layout.length; i++) {
+		const item = layout[i];
+		if (item.kind === 'guild') {
+			if (item.guildId === guildId) {
+				layout.splice(i, 1);
+				return {
+					guild: {
+						guildId: item.guildId,
+						notifications: item.notifications,
+						readStates: item.readStates
+					},
+					removedIndex: i
+				};
+			}
+			continue;
+		}
+		const idx = item.guilds.findIndex((guild) => guild.guildId === guildId);
+		if (idx === -1) continue;
+		const [removed] = item.guilds.splice(idx, 1);
+		if (item.guilds.length === 0) {
+			layout.splice(i, 1);
+			return { guild: removed, removedIndex: i };
+		}
+		if (item.guilds.length === 1) {
+			const [remaining] = item.guilds;
+			layout.splice(i, 1, { kind: 'guild', ...remaining });
+			return { guild: removed, removedIndex: null };
+		}
+		return { guild: removed, removedIndex: null };
+	}
+	return { guild: null, removedIndex: null };
 }
 
 export function moveGuildToTop(guildId: string, targetIndex: number) {
-        mutateAppSettings((settings) => {
-                const layout = settings.guildLayout;
-                const { guild, removedIndex } = detachGuild(layout, guildId);
-                if (!guild) return false;
-                let index = targetIndex;
-                if (removedIndex != null && removedIndex < index) {
-                        index -= 1;
-                }
-                index = clamp(index, 0, layout.length);
-                layout.splice(index, 0, { kind: 'guild', ...guild });
-                return true;
-        });
+	mutateAppSettings((settings) => {
+		const layout = settings.guildLayout;
+		const { guild, removedIndex } = detachGuild(layout, guildId);
+		if (!guild) return false;
+		let index = targetIndex;
+		if (removedIndex != null && removedIndex < index) {
+			index -= 1;
+		}
+		index = clamp(index, 0, layout.length);
+		layout.splice(index, 0, { kind: 'guild', ...guild });
+		return true;
+	});
 }
 
 export function moveFolder(folderId: string, targetIndex: number) {
-        mutateAppSettings((settings) => {
-                const layout = settings.guildLayout;
-                const currentIndex = layout.findIndex(
-                        (item) => item.kind === 'folder' && item.id === folderId
-                );
-                if (currentIndex === -1) return false;
-                const [folder] = layout.splice(currentIndex, 1) as [GuildFolderItem];
-                let index = targetIndex;
-                if (currentIndex < index) index -= 1;
-                index = clamp(index, 0, layout.length);
-                layout.splice(index, 0, folder);
-                return true;
-        });
+	mutateAppSettings((settings) => {
+		const layout = settings.guildLayout;
+		const currentIndex = layout.findIndex((item) => item.kind === 'folder' && item.id === folderId);
+		if (currentIndex === -1) return false;
+		const [folder] = layout.splice(currentIndex, 1) as [GuildFolderItem];
+		let index = targetIndex;
+		if (currentIndex < index) index -= 1;
+		index = clamp(index, 0, layout.length);
+		layout.splice(index, 0, folder);
+		return true;
+	});
 }
 
 export function moveGuildToFolder(guildId: string, folderId: string, targetIndex?: number) {
-        mutateAppSettings((settings) => {
-                const layout = settings.guildLayout;
-                const folderIndex = layout.findIndex(
-                        (item) => item.kind === 'folder' && item.id === folderId
-                );
-                if (folderIndex === -1) return false;
-                const folder = layout[folderIndex] as GuildFolderItem;
-                const existingIndex = folder.guilds.findIndex((guild) => guild.guildId === guildId);
-                let guild: GuildLayoutGuild | null = null;
-                if (existingIndex !== -1) {
-                        const [removed] = folder.guilds.splice(existingIndex, 1);
-                        guild = removed;
-                        if (existingIndex < (targetIndex ?? folder.guilds.length)) {
-                                targetIndex = (targetIndex ?? folder.guilds.length) - 1;
-                        }
-                } else {
-                        const result = detachGuild(layout, guildId);
-                        guild = result.guild;
-                        if (!guild) return false;
-                        const updatedIndex = layout.findIndex(
-                                (item) => item.kind === 'folder' && item.id === folderId
-                        );
-                        if (updatedIndex === -1) return false;
-                        const targetFolder = layout[updatedIndex] as GuildFolderItem;
-                        const index = clamp(targetIndex ?? targetFolder.guilds.length, 0, targetFolder.guilds.length);
-                        targetFolder.guilds.splice(index, 0, guild);
-                        return true;
-                }
-                const index = clamp(targetIndex ?? folder.guilds.length, 0, folder.guilds.length);
-                folder.guilds.splice(index, 0, guild);
-                return true;
-        });
+	mutateAppSettings((settings) => {
+		const layout = settings.guildLayout;
+		const folderIndex = layout.findIndex((item) => item.kind === 'folder' && item.id === folderId);
+		if (folderIndex === -1) return false;
+		const folder = layout[folderIndex] as GuildFolderItem;
+		const existingIndex = folder.guilds.findIndex((guild) => guild.guildId === guildId);
+		let guild: GuildLayoutGuild | null = null;
+		if (existingIndex !== -1) {
+			const [removed] = folder.guilds.splice(existingIndex, 1);
+			guild = removed;
+			if (existingIndex < (targetIndex ?? folder.guilds.length)) {
+				targetIndex = (targetIndex ?? folder.guilds.length) - 1;
+			}
+		} else {
+			const result = detachGuild(layout, guildId);
+			guild = result.guild;
+			if (!guild) return false;
+			const updatedIndex = layout.findIndex(
+				(item) => item.kind === 'folder' && item.id === folderId
+			);
+			if (updatedIndex === -1) return false;
+			const targetFolder = layout[updatedIndex] as GuildFolderItem;
+			const index = clamp(targetIndex ?? targetFolder.guilds.length, 0, targetFolder.guilds.length);
+			targetFolder.guilds.splice(index, 0, guild);
+			return true;
+		}
+		const index = clamp(targetIndex ?? folder.guilds.length, 0, folder.guilds.length);
+		folder.guilds.splice(index, 0, guild);
+		return true;
+	});
 }
 
 export function createFolderWithGuilds(
-        anchorGuildId: string,
-        otherGuildId: string,
-        insertIndex?: number
+	anchorGuildId: string,
+	otherGuildId: string,
+	insertIndex?: number
 ): string | null {
-        let createdId: string | null = null;
-        mutateAppSettings((settings) => {
-                const layout = settings.guildLayout;
-                const { guild: anchorGuild, removedIndex: anchorIndex } = detachGuild(
-                        layout,
-                        anchorGuildId
-                );
-                const { guild: otherGuild, removedIndex: otherIndex } = detachGuild(
-                        layout,
-                        otherGuildId
-                );
-                if (!anchorGuild || !otherGuild) return false;
-                let index = insertIndex ?? anchorIndex ?? layout.length;
-                if (otherIndex != null && otherIndex < index) index -= 1;
-                index = clamp(index, 0, layout.length);
-                const folder: GuildFolderItem = {
-                        kind: 'folder',
-                        id: generateFolderId(),
-                        name: null,
-                        color: null,
-                        guilds: [anchorGuild, otherGuild]
-                };
-                layout.splice(index, 0, folder);
-                createdId = folder.id;
-                return true;
-        });
-        return createdId;
+	let createdId: string | null = null;
+	mutateAppSettings((settings) => {
+		const layout = settings.guildLayout;
+		const { guild: anchorGuild, removedIndex: anchorIndex } = detachGuild(layout, anchorGuildId);
+		const { guild: otherGuild, removedIndex: otherIndex } = detachGuild(layout, otherGuildId);
+		if (!anchorGuild || !otherGuild) return false;
+		let index = insertIndex ?? anchorIndex ?? layout.length;
+		if (otherIndex != null && otherIndex < index) index -= 1;
+		index = clamp(index, 0, layout.length);
+		const folder: GuildFolderItem = {
+			kind: 'folder',
+			id: generateFolderId(),
+			name: null,
+			color: null,
+			guilds: [anchorGuild, otherGuild]
+		};
+		layout.splice(index, 0, folder);
+		createdId = folder.id;
+		return true;
+	});
+	return createdId;
 }
 
 function syncLayoutWithGuilds() {
-        const guildList = latestGuilds ?? [];
+	const guildList = latestGuilds ?? [];
 
-        if (guildList.length > 0) {
-                hasSyncedGuildLayout = true;
-        } else if (!hasSyncedGuildLayout) {
-                return;
-        }
+	if (guildList.length > 0) {
+		hasSyncedGuildLayout = true;
+	} else if (!hasSyncedGuildLayout) {
+		return;
+	}
 
-        mutateAppSettings((settings) => {
-                if (guildList.length === 0) {
-                        if (settings.guildLayout.length === 0) return false;
-                        settings.guildLayout = [];
-                        return true;
-                }
+	mutateAppSettings((settings) => {
+		if (guildList.length === 0) {
+			if (settings.guildLayout.length === 0) return false;
+			settings.guildLayout = [];
+			return true;
+		}
 
-                const available = new Set(
-                        guildList
-                                .map((guild) => toSnowflakeString((guild as any)?.id))
-                                .filter((id): id is string => Boolean(id))
-                );
-                const seen = new Set<string>();
-                const newLayout: GuildLayoutItem[] = [];
-                let changed = false;
+		const available = new Set(
+			guildList
+				.map((guild) => toSnowflakeString((guild as any)?.id))
+				.filter((id): id is string => Boolean(id))
+		);
+		const seen = new Set<string>();
+		const newLayout: GuildLayoutItem[] = [];
+		let changed = false;
 
-                for (const item of settings.guildLayout) {
-                        if (item.kind === 'guild') {
-                                if (available.has(item.guildId)) {
-                                        newLayout.push(item);
-                                        seen.add(item.guildId);
-                                } else {
-                                        changed = true;
-                                }
-                                continue;
-                        }
-                        const keptGuilds = item.guilds.filter((guild) => {
-                                if (available.has(guild.guildId)) {
-                                        seen.add(guild.guildId);
-                                        return true;
-                                }
-                                changed = true;
-                                return false;
-                        });
-                        if (keptGuilds.length >= 2) {
-                                if (keptGuilds.length !== item.guilds.length) changed = true;
-                                newLayout.push({ ...item, guilds: keptGuilds });
-                        } else if (keptGuilds.length === 1) {
-                                changed = true;
-                                newLayout.push({ kind: 'guild', ...keptGuilds[0] });
-                        } else {
-                                changed = true;
-                        }
-                }
+		for (const item of settings.guildLayout) {
+			if (item.kind === 'guild') {
+				if (available.has(item.guildId)) {
+					newLayout.push(item);
+					seen.add(item.guildId);
+				} else {
+					changed = true;
+				}
+				continue;
+			}
+			const keptGuilds = item.guilds.filter((guild) => {
+				if (available.has(guild.guildId)) {
+					seen.add(guild.guildId);
+					return true;
+				}
+				changed = true;
+				return false;
+			});
+			if (keptGuilds.length >= 2) {
+				if (keptGuilds.length !== item.guilds.length) changed = true;
+				newLayout.push({ ...item, guilds: keptGuilds });
+			} else if (keptGuilds.length === 1) {
+				changed = true;
+				newLayout.push({ kind: 'guild', ...keptGuilds[0] });
+			} else {
+				changed = true;
+			}
+		}
 
-                for (const id of available) {
-                        if (!seen.has(id)) {
-                                newLayout.push({ kind: 'guild', guildId: id });
-                                changed = true;
-                        }
-                }
+		for (const id of available) {
+			if (!seen.has(id)) {
+				newLayout.push({ kind: 'guild', guildId: id });
+				changed = true;
+			}
+		}
 
-                if (!changed) return false;
-                settings.guildLayout = newLayout;
-                return true;
-        });
+		if (!changed) return false;
+		settings.guildLayout = newLayout;
+		return true;
+	});
 }
 
 async function loadSettingsFromApi() {
-        hasSyncedGuildLayout = false;
-        if (!get(auth.isAuthenticated)) {
-                suppressSave = true;
-                appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
-                suppressSave = false;
-                settingsReady.set(false);
-                return;
-        }
-        try {
-                const response = await auth.api.user.userMeSettingsGet();
-                if (response.status === 204 || !response.data?.settings) {
-                        suppressSave = true;
-                        appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
-                        suppressSave = false;
-                } else {
-                        const parsed = convertFromApi(response.data.settings);
-                        suppressSave = true;
-                        suppressThemePropagation = true;
-                        suppressLocalePropagation = true;
-                        appSettings.set(parsed);
-                        theme.set(parsed.theme);
-                        locale.set(parsed.language);
-                        suppressThemePropagation = false;
-                        suppressLocalePropagation = false;
-                        suppressSave = false;
-                }
-        } catch (error) {
-                console.error('Failed to load settings', error);
-                suppressSave = true;
-                appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
-                suppressSave = false;
-        }
-        settingsReady.set(true);
-        syncLayoutWithGuilds();
+	hasSyncedGuildLayout = false;
+	if (!get(auth.isAuthenticated)) {
+		suppressSave = true;
+		appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
+		suppressSave = false;
+		settingsReady.set(false);
+		return;
+	}
+	try {
+		const response = await auth.api.user.userMeSettingsGet();
+		if (response.status === 204 || !response.data?.settings) {
+			suppressSave = true;
+			appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
+			applySelectedGuildFromSettings(false);
+			suppressSave = false;
+		} else {
+			const parsed = convertFromApi(response.data.settings);
+			suppressSave = true;
+			suppressThemePropagation = true;
+			suppressLocalePropagation = true;
+			appSettings.set(parsed);
+			applySelectedGuildFromSettings(false);
+			theme.set(parsed.theme);
+			locale.set(parsed.language);
+			suppressThemePropagation = false;
+			suppressLocalePropagation = false;
+			suppressSave = false;
+		}
+	} catch (error) {
+		console.error('Failed to load settings', error);
+		suppressSave = true;
+		appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
+		applySelectedGuildFromSettings(false);
+		suppressSave = false;
+	}
+	settingsReady.set(true);
+	applySelectedGuildFromSettings(true);
+	syncLayoutWithGuilds();
 }
 
 auth.token.subscribe((token) => {
-        if (token) {
-                void loadSettingsFromApi();
-        } else {
-                hasSyncedGuildLayout = false;
-                suppressSave = true;
-                appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
-                suppressSave = false;
-                settingsReady.set(false);
-        }
+	if (token) {
+		void loadSettingsFromApi();
+	} else {
+		hasSyncedGuildLayout = false;
+		guildsHydrated = false;
+		suppressSave = true;
+		appSettings.set({ ...defaultSettings, language: get(locale), theme: get(theme) });
+		suppressSave = false;
+		settingsReady.set(false);
+	}
 });
 
 auth.guilds.subscribe((guilds) => {
-        latestGuilds = Array.isArray(guilds) ? guilds : [];
-        if (get(settingsReady)) {
-                syncLayoutWithGuilds();
-        }
+	latestGuilds = Array.isArray(guilds) ? guilds : [];
+	if (get(settingsReady)) {
+		guildsHydrated = true;
+	}
+	applySelectedGuildFromSettings(get(settingsReady));
+	if (get(settingsReady)) {
+		syncLayoutWithGuilds();
+	}
 });
 
 theme.subscribe((value) => {
-        if (suppressThemePropagation) return;
-        mutateAppSettings((settings) => {
-                if (settings.theme === value) return false;
-                settings.theme = value;
-                return true;
-        });
+	if (suppressThemePropagation) return;
+	mutateAppSettings((settings) => {
+		if (settings.theme === value) return false;
+		settings.theme = value;
+		return true;
+	});
 });
 
 locale.subscribe((value) => {
-        if (suppressLocalePropagation) return;
-        mutateAppSettings((settings) => {
-                if (settings.language === value) return false;
-                settings.language = value;
-                return true;
-        });
+	if (suppressLocalePropagation) return;
+	mutateAppSettings((settings) => {
+		if (settings.language === value) return false;
+		settings.language = value;
+		return true;
+	});
 });
 
 export const hasFolders = derived(appSettings, ($settings) =>
-        $settings.guildLayout.some((item) => item.kind === 'folder')
+	$settings.guildLayout.some((item) => item.kind === 'folder')
 );
 
 export { settingsOpen as userSettingsOpen };


### PR DESCRIPTION
## Summary
- add a persisted `selectedGuildId` to app settings with API serialization
- apply stored guild selections on settings load with fallbacks when guilds are unavailable
- persist guild selection changes through `mutateAppSettings` in guild selection flows and server bar UI

## Testing
- npm run lint *(fails: Prettier reports existing formatting issues across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b0874a008322ab85505040ec36a6