### PR TITLE
fix: replace MessageList afterUpdate with runic effect

### DIFF
--- a/src/lib/components/app/chat/MessageList.svelte
+++ b/src/lib/components/app/chat/MessageList.svelte
@@ -12,7 +12,7 @@
         import { wsEvent } from '$lib/client/ws';
         import { m } from '$lib/paraglide/messages.js';
         import { fly } from 'svelte/transition';
-        import { afterUpdate, onDestroy, onMount, tick, untrack } from 'svelte';
+        import { onDestroy, onMount, tick, untrack } from 'svelte';
         import { Sparkles } from 'lucide-svelte';
         import {
                 mutateAppSettings,
@@ -198,8 +198,19 @@
                 flushPendingReadStates();
         });
 
-        afterUpdate(() => {
-                recordReadState();
+        $effect(() => {
+                if (!initialLoaded) return;
+                const dependencies = {
+                        count: messages.length,
+                        wasAtBottom,
+                        endReached,
+                        latestReached,
+                        newCount
+                };
+                void dependencies;
+                queueMicrotask(() => {
+                        recordReadState();
+                });
         });
 
         $effect(() => {


### PR DESCRIPTION
## Summary
- replace the MessageList afterUpdate lifecycle usage with a runic effect compatible with Svelte 5 runes mode
- schedule read state recording via queueMicrotask after message list state changes

## Testing
- npm run check *(fails: pre-existing type mismatch in src/lib/stores/settings.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b63e48f4832294fe76416c893184