### PR TITLE
fix: increase settings save debounce interval

### DIFF
--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -174,6 +174,8 @@ let suppressThemePropagation = false;
 let suppressLocalePropagation = false;
 let suppressSave = false;
 
+const SETTINGS_SAVE_DEBOUNCE_MS = 30_000;
+
 let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 let saveDirty = false;
 let saveInFlight = false;
@@ -510,10 +512,10 @@ function scheduleSave() {
 	if (!get(auth.isAuthenticated)) return;
 	saveDirty = true;
 	if (saveTimeout) clearTimeout(saveTimeout);
-	saveTimeout = setTimeout(() => {
-		saveTimeout = null;
-		void persistSettings();
-	}, 400);
+        saveTimeout = setTimeout(() => {
+                saveTimeout = null;
+                void persistSettings();
+        }, SETTINGS_SAVE_DEBOUNCE_MS);
 }
 
 async function persistSettings() {
@@ -537,13 +539,13 @@ async function persistSettings() {
 	} finally {
 		saveInFlight = false;
 		settingsSaving.set(false);
-		if (saveDirty && !saveTimeout) {
-			saveTimeout = setTimeout(() => {
-				saveTimeout = null;
-				void persistSettings();
-			}, 400);
-		}
-	}
+                if (saveDirty && !saveTimeout) {
+                        saveTimeout = setTimeout(() => {
+                                saveTimeout = null;
+                                void persistSettings();
+                        }, SETTINGS_SAVE_DEBOUNCE_MS);
+                }
+        }
 }
 
 type SettingsMutator = (settings: AppSettings) => boolean;


### PR DESCRIPTION
## Summary
- introduce a shared SETTINGS_SAVE_DEBOUNCE_MS constant for settings persistence timing
- reuse the constant for save scheduling and retries to debounce saves to ~30 seconds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1a8d35e98832297d8948eb6a408b9