### PR TITLE
fix: respect focused window for unread markers

### DIFF
--- a/src/lib/client/ws.ts
+++ b/src/lib/client/ws.ts
@@ -7,6 +7,7 @@ import {
   membersByGuild,
   messagesByChannel,
   myGuildRoleIdsByGuild,
+  appHasFocus,
   selectedChannelId,
   selectedGuildId
 } from '$lib/stores/appState';
@@ -418,7 +419,21 @@ export function connectWS() {
           normalizeSnowflake(message?.id) ??
           normalizeSnowflake(payload?.id);
         if (guildId && channelId && messageId) {
-          markChannelUnread(guildId, channelId, messageId);
+          let shouldMarkUnread = true;
+          if (browser) {
+            const focused = Boolean(get(appHasFocus));
+            if (focused) {
+              const activeGuildId = normalizeSnowflake(get(selectedGuildId));
+              const activeChannelId = normalizeSnowflake(get(selectedChannelId));
+              if (guildId === activeGuildId && channelId === activeChannelId) {
+                shouldMarkUnread = false;
+              }
+            }
+          }
+
+          if (shouldMarkUnread) {
+            markChannelUnread(guildId, channelId, messageId);
+          }
         }
       }
 

--- a/src/lib/stores/appState.ts
+++ b/src/lib/stores/appState.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { browser } from '$app/environment';
 import type { DtoChannel, DtoMember, DtoMessage } from '$lib/api';
 
 export const selectedGuildId = writable<string | null>(null);
@@ -33,3 +34,8 @@ export const messageJumpRequest = writable<
 
 // Guild settings overlay state
 export const guildSettingsOpen = writable(false);
+
+const currentFocusState = () =>
+        browser ? document.visibilityState === 'visible' && document.hasFocus() : true;
+
+export const appHasFocus = writable(currentFocusState());

--- a/src/routes/app/AppPage.svelte
+++ b/src/routes/app/AppPage.svelte
@@ -1,14 +1,32 @@
 <script lang="ts">
-	import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
-	import ServerBar from '$lib/components/app/sidebar/ServerBar.svelte';
-	import ChannelPane from '$lib/components/app/sidebar/ChannelPane.svelte';
-	import ChatPane from '$lib/components/app/chat/ChatPane.svelte';
-	import SearchPanel from '$lib/components/app/search/SearchPanel.svelte';
+        import { onMount } from 'svelte';
+        import { browser } from '$app/environment';
+        import AuthGate from '$lib/components/app/auth/AuthGate.svelte';
+        import ServerBar from '$lib/components/app/sidebar/ServerBar.svelte';
+        import ChannelPane from '$lib/components/app/sidebar/ChannelPane.svelte';
+        import ChatPane from '$lib/components/app/chat/ChatPane.svelte';
+        import SearchPanel from '$lib/components/app/search/SearchPanel.svelte';
         import DmCreate from '$lib/components/app/dm/DmCreate.svelte';
-	import ContextMenu from '$lib/components/ui/ContextMenu.svelte';
-	import { searchOpen } from '$lib/stores/appState';
-	import '$lib/client/ws';
-	import { m } from '$lib/paraglide/messages.js';
+        import ContextMenu from '$lib/components/ui/ContextMenu.svelte';
+        import { appHasFocus, searchOpen } from '$lib/stores/appState';
+        import '$lib/client/ws';
+        import { m } from '$lib/paraglide/messages.js';
+
+        const updateAppFocus = () => {
+                if (!browser) return;
+                appHasFocus.set(document.visibilityState === 'visible' && document.hasFocus());
+        };
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+                if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
+                        e.preventDefault();
+                        searchOpen.set(true);
+                }
+        };
+
+        onMount(() => {
+                updateAppFocus();
+        });
 
 </script>
 
@@ -32,10 +50,8 @@
 </AuthGate>
 
 <svelte:window
-	on:keydown={(e) => {
-		if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k') {
-			e.preventDefault();
-			searchOpen.set(true);
-		}
-	}}
+        on:focus={updateAppFocus}
+        on:blur={updateAppFocus}
+        on:visibilitychange={updateAppFocus}
+        on:keydown={handleKeyDown}
 />


### PR DESCRIPTION
## Summary
- add an appHasFocus store that tracks browser focus/visibility state
- sync the focus store from AppPage window events
- skip marking the active channel unread when the focused window receives a message

## Testing
- npm run lint *(fails: repository has numerous existing Prettier formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b000d88883228c6899204dbd3b64