### PR TITLE
feat: add folder context menu actions

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -22,6 +22,7 @@
 	"general": "Allgemein",
         "appearance": "Darstellung",
         "folder_settings": "Ordner-Einstellungen",
+        "folder_settings_action": "Ordner-Einstellungen",
         "folder_settings_description": "Verwalte die Serverordner in deiner Seitenleiste.",
         "folder_settings_empty": "Du hast noch keine Ordner.",
         "folder_name": "Ordnername",

--- a/messages/en.json
+++ b/messages/en.json
@@ -55,6 +55,7 @@
 	"general": "General",
         "appearance": "Appearance",
         "folder_settings": "Folder settings",
+        "folder_settings_action": "Folder settings",
         "folder_settings_description": "Manage server folders shown in your sidebar.",
         "folder_settings_empty": "You don't have any folders yet.",
         "folder_name": "Folder name",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -22,6 +22,7 @@
 	"general": "Général",
         "appearance": "Apparence",
         "folder_settings": "Paramètres des dossiers",
+        "folder_settings_action": "Paramètres des dossiers",
         "folder_settings_description": "Gérez les dossiers de serveurs affichés dans votre barre latérale.",
         "folder_settings_empty": "Vous n'avez encore aucun dossier.",
         "folder_name": "Nom du dossier",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -55,6 +55,7 @@
         "general": "Общие",
         "appearance": "Оформление",
         "folder_settings": "Настройки папок",
+        "folder_settings_action": "Настройки папки",
         "folder_settings_description": "Управляйте папками серверов в боковой панели.",
         "folder_settings_empty": "У вас пока нет папок.",
         "folder_name": "Название папки",

--- a/src/lib/components/app/settings/SettingsOverlay.svelte
+++ b/src/lib/components/app/settings/SettingsOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { settingsOpen, theme, locale } from '$lib/stores/settings';
+        import { settingsOpen, theme, locale, folderSettingsRequest } from '$lib/stores/settings';
 	import { m } from '$lib/paraglide/messages.js';
 	import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
 	import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
@@ -29,11 +29,24 @@
 		{ value: 'dark', label: () => m.dark() }
 	];
 
-	let category = $state<'profile' | 'general' | 'appearance' | 'folders' | 'other'>('profile');
+        let category = $state<'profile' | 'general' | 'appearance' | 'folders' | 'other'>('profile');
+        let folderFocusRequest = $state<{
+                folderId: string;
+                requestId: number;
+        } | null>(null);
 
-	function closeOverlay() {
-		settingsOpen.set(false);
-	}
+        function closeOverlay() {
+                settingsOpen.set(false);
+                folderFocusRequest = null;
+        }
+
+        $effect(() => {
+                const request = $folderSettingsRequest;
+                if (!request) return;
+                category = 'folders';
+                folderFocusRequest = request;
+                folderSettingsRequest.set(null);
+        });
 </script>
 
 <SettingsPanel bind:open={$settingsOpen} on:close={closeOverlay}>
@@ -166,8 +179,8 @@
 				{/each}
 			</div>
 		</div>
-	{:else if category === 'folders'}
-		<FolderSettings />
+        {:else if category === 'folders'}
+                <FolderSettings focusRequest={folderFocusRequest} />
 	{:else}
 		<p>{m.other()}...</p>
 	{/if}

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -167,6 +167,13 @@ export const guildChannelReadStateLookup = derived(appSettings, ($settings) => {
         return lookup;
 });
 export const settingsOpen = writable(false);
+export const folderSettingsRequest = writable<
+        | {
+                folderId: string;
+                requestId: number;
+        }
+        | null
+>(null);
 export const settingsReady = writable(false);
 export const settingsSaving = writable(false);
 
@@ -464,7 +471,7 @@ function convertToApi(settings: AppSettings): ModelUserSettingsData {
 			chat_spacing: settings.chatSpacing
 		},
 		guilds: payloadGuilds,
-		guild_folders: payloadFolders as unknown as ModelUserSettingsGuildFolders,
+                guild_folders: payloadFolders as unknown as ModelUserSettingsGuildFolders[],
 		selected_guild: settings.selectedGuildId ? toApiSnowflake(settings.selectedGuildId) : undefined
 	};
 }


### PR DESCRIPTION
## Summary
- add a context menu entry for sidebar folders that opens the settings overlay
- add a store-driven request flow so the overlay jumps to the folder tab and focuses the target folder
- localize the new menu label across supported languages and tighten folder payload typing

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e1c891e81483229fb8c0983c403909