### PR TITLE
Add dedicated folder settings overlay

### DIFF
--- a/src/lib/components/app/settings/FolderSettingsOverlay.svelte
+++ b/src/lib/components/app/settings/FolderSettingsOverlay.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+        import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
+        import FolderSettings from '$lib/components/app/settings/FolderSettings.svelte';
+        import { folderSettingsOpen, folderSettingsRequest } from '$lib/stores/settings';
+
+        let focusRequest = $state<{
+                folderId: string;
+                requestId: number;
+        } | null>(null);
+
+        function closeOverlay() {
+                folderSettingsOpen.set(false);
+                focusRequest = null;
+        }
+
+        $effect(() => {
+                if (!$folderSettingsOpen) {
+                        focusRequest = null;
+                }
+        });
+
+        $effect(() => {
+                const request = $folderSettingsRequest;
+                if (!request) return;
+                focusRequest = request;
+                folderSettingsOpen.set(true);
+                folderSettingsRequest.set(null);
+        });
+</script>
+
+<SettingsPanel
+        bind:open={$folderSettingsOpen}
+        on:close={closeOverlay}
+        sidebarClass="hidden border-none p-0"
+>
+        <FolderSettings focusRequest={focusRequest} />
+</SettingsPanel>

--- a/src/lib/components/app/settings/SettingsOverlay.svelte
+++ b/src/lib/components/app/settings/SettingsOverlay.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-        import { settingsOpen, theme, locale, folderSettingsRequest } from '$lib/stores/settings';
+        import { settingsOpen, theme, locale } from '$lib/stores/settings';
 	import { m } from '$lib/paraglide/messages.js';
 	import ProfileEdit from '$lib/components/app/user/ProfileEdit.svelte';
 	import SettingsPanel from '$lib/components/ui/SettingsPanel.svelte';
-	import FolderSettings from '$lib/components/app/settings/FolderSettings.svelte';
 	import type { Theme, Locale } from '$lib/stores/settings';
 
 	type LanguageOption = {
@@ -29,24 +28,11 @@
 		{ value: 'dark', label: () => m.dark() }
 	];
 
-        let category = $state<'profile' | 'general' | 'appearance' | 'folders' | 'other'>('profile');
-        let folderFocusRequest = $state<{
-                folderId: string;
-                requestId: number;
-        } | null>(null);
+        let category = $state<'profile' | 'general' | 'appearance' | 'other'>('profile');
 
         function closeOverlay() {
                 settingsOpen.set(false);
-                folderFocusRequest = null;
         }
-
-        $effect(() => {
-                const request = $folderSettingsRequest;
-                if (!request) return;
-                category = 'folders';
-                folderFocusRequest = request;
-                folderSettingsRequest.set(null);
-        });
 </script>
 
 <SettingsPanel bind:open={$settingsOpen} on:close={closeOverlay}>
@@ -74,14 +60,6 @@
 			onclick={() => (category = 'appearance')}
 		>
 			{m.appearance()}
-		</button>
-		<button
-			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'folders'
-				? 'bg-[var(--panel)] font-semibold'
-				: ''}"
-			onclick={() => (category = 'folders')}
-		>
-			{m.folder_settings()}
 		</button>
 		<button
 			class="w-full rounded px-2 py-1 text-left hover:bg-[var(--panel)] {category === 'other'
@@ -179,9 +157,7 @@
 				{/each}
 			</div>
 		</div>
-        {:else if category === 'folders'}
-                <FolderSettings focusRequest={folderFocusRequest} />
-	{:else}
-		<p>{m.other()}...</p>
-	{/if}
+        {:else}
+                <p>{m.other()}...</p>
+        {/if}
 </SettingsPanel>

--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -7,7 +7,7 @@
                 moveFolder,
                 moveGuildToFolder,
                 moveGuildToTop,
-                settingsOpen,
+                folderSettingsOpen,
                 folderSettingsRequest
         } from '$lib/stores/settings';
 	import { auth } from '$lib/stores/auth';
@@ -376,7 +376,7 @@
                         {
                                 label: m.folder_settings_action(),
                                 action: () => {
-                                        settingsOpen.set(true);
+                                        folderSettingsOpen.set(true);
                                         folderSettingsRequest.set({
                                                 folderId: folder.folder.id,
                                                 requestId: Date.now(),

--- a/src/lib/stores/settings.ts
+++ b/src/lib/stores/settings.ts
@@ -167,6 +167,7 @@ export const guildChannelReadStateLookup = derived(appSettings, ($settings) => {
         return lookup;
 });
 export const settingsOpen = writable(false);
+export const folderSettingsOpen = writable(false);
 export const folderSettingsRequest = writable<
         | {
                 folderId: string;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import '../app.css';
 	import favicon from '$lib/assets/favicon.svg';
-	import SettingsOverlay from '$lib/components/app/settings/SettingsOverlay.svelte';
-	import GuildSettingsOverlay from '$lib/components/app/settings/GuildSettingsOverlay.svelte';
+        import SettingsOverlay from '$lib/components/app/settings/SettingsOverlay.svelte';
+        import FolderSettingsOverlay from '$lib/components/app/settings/FolderSettingsOverlay.svelte';
+        import GuildSettingsOverlay from '$lib/components/app/settings/GuildSettingsOverlay.svelte';
 	import ConnectionStatusBar from '$lib/components/app/ConnectionStatusBar.svelte';
 
 	let { children } = $props();
@@ -15,5 +16,6 @@
 {@render children?.()}
 
 <SettingsOverlay />
+<FolderSettingsOverlay />
 <GuildSettingsOverlay />
 <ConnectionStatusBar />


### PR DESCRIPTION
## Summary
- add a dedicated `folderSettingsOpen` store and overlay for folder settings
- mount the new folder settings overlay alongside the existing global overlays
- update server bar actions and remove the folder tab from the main settings modal

## Testing
- npm run lint *(fails: repository has existing Prettier formatting issues across multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68e1cc0a5bd483228f25ecfa7a9f2633