### PR TITLE
fix: restyle unread badges on server bar

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -470,7 +470,7 @@
                                 {@const guildUnread = guildHasUnread(item.guildId)}
                                 <div class="group relative flex justify-center">
                                         <button
-                                                class={`relative flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+                                                class={`relative flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] pl-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
                                                         isGuildSelected(item.guildId) ? 'shadow ring-2 ring-[var(--brand)] ring-inset' : ''
                                                 } ${mergeTargetGuild === item.guildId ? 'ring-2 ring-[var(--brand)]' : ''}`}
                                                 title={item.guild.name}
@@ -489,7 +489,7 @@
                                                         <span class="sr-only">{m.unread_indicator()}</span>
                                                         <span
                                                                 aria-hidden="true"
-                                                                class="absolute -right-1 top-0 h-2 w-2 rounded-full bg-[var(--brand)] ring-2 ring-[var(--panel-strong)]"
+                                                                class="absolute -left-1.5 top-1/2 h-6 w-1.5 -translate-y-1/2 rounded-full bg-[var(--brand)]"
                                                         ></span>
                                                 {/if}
                                         </button>
@@ -519,7 +519,7 @@
                                 >
                                         <div class="relative">
                                                 <button
-                                                        class={`relative flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--folder-collapsed-border)] bg-[var(--folder-collapsed-bg)] p-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+                                                        class={`relative flex h-12 w-12 flex-col items-center justify-center gap-1 rounded-xl border border-[var(--folder-collapsed-border)] bg-[var(--folder-collapsed-bg)] p-1 pl-2 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
                                                                 folderIsDropTarget
                                                                         ? 'ring-2 ring-[var(--brand)]'
                                                                         : folderHasSelection
@@ -554,7 +554,7 @@
                                                                         {#each item.guilds.slice(0, 4) as guildPreview, idx (guildPreview.guildId)}
                                                                                 {@const previewUnread = guildHasUnread(guildPreview.guildId)}
                                                                                 <div
-                                                                                        class={`relative flex items-center justify-center rounded-lg border border-[var(--stroke)] bg-[var(--panel)] text-xs font-semibold ${
+                                                                                        class={`relative flex items-center justify-center rounded-lg border border-[var(--stroke)] bg-[var(--panel)] pl-1 text-xs font-semibold ${
                                                                                                 guildPreview.guildId === $selectedGuildId ? 'border-[var(--brand)]' : ''
                                                                                         } ${previewUnread ? 'border-[var(--brand)] bg-[var(--brand)]/10' : ''}`}
                                                                                 >
@@ -563,7 +563,7 @@
                                                                                                 <span class="sr-only">{m.unread_indicator()}</span>
                                                                                                 <span
                                                                                                         aria-hidden="true"
-                                                                                                        class="absolute -right-1 top-0 h-1.5 w-1.5 rounded-full bg-[var(--brand)]"
+                                                                                                        class="absolute -left-1.5 top-1/2 h-6 w-1.5 -translate-y-1/2 rounded-full bg-[var(--brand)]"
                                                                                                 ></span>
                                                                                         {/if}
                                                                                 </div>
@@ -579,7 +579,7 @@
                                                                 <span class="sr-only">{m.unread_indicator()}</span>
                                                                 <span
                                                                         aria-hidden="true"
-                                                                        class="absolute -right-1 top-0 h-2 w-2 rounded-full bg-[var(--brand)] ring-2 ring-[var(--panel-strong)]"
+                                                                        class="absolute -left-1.5 top-1/2 h-6 w-1.5 -translate-y-1/2 rounded-full bg-[var(--brand)]"
                                                                 ></span>
                                                         {/if}
                                                 </button>
@@ -603,7 +603,7 @@
                                                                 {@const nestedGuildUnread = guildHasUnread(nestedGuild.guildId)}
                                                                 <div class="group relative flex justify-center">
                                                                         <button
-                                                                                class={`relative flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
+                                                                                class={`relative flex h-12 w-12 transform items-center justify-center rounded-xl border border-[var(--stroke)] bg-[var(--panel-strong)] pl-1 transition-all duration-150 hover:-translate-y-0.5 hover:scale-105 hover:bg-[var(--panel)] hover:ring-2 hover:ring-[var(--brand)] hover:ring-inset focus-visible:outline-none ${
                                                                                         isGuildSelected(nestedGuild.guildId)
                                                                                                 ? 'shadow ring-2 ring-[var(--brand)] ring-inset'
                                                                                                 : ''
@@ -630,7 +630,7 @@
                                                                                         <span class="sr-only">{m.unread_indicator()}</span>
                                                                                         <span
                                                                                                 aria-hidden="true"
-                                                                                                class="absolute -right-1 top-0 h-2 w-2 rounded-full bg-[var(--brand)] ring-2 ring-[var(--panel-strong)]"
+                                                                                                class="absolute -left-1.5 top-1/2 h-6 w-1.5 -translate-y-1/2 rounded-full bg-[var(--brand)]"
                                                                                         ></span>
                                                                                 {/if}
                                                                         </button>


### PR DESCRIPTION
## Summary
- move unread indicators to left-aligned vertical pills that match Discord styling
- add interior padding so guild, folder, and preview buttons clear the new badge placement
- ensure nested guilds and folder previews use the same unread indicator treatment for alignment

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e1d63b3fe4832283a44be93f08c557