### PR TITLE
fix: ignore unread frames when handling message deletions

### DIFF
--- a/src/lib/components/app/chat/messageEventHandlers.spec.ts
+++ b/src/lib/components/app/chat/messageEventHandlers.spec.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import type { DtoMessage } from '$lib/api';
+import { applyMessageEventToList } from './messageEventHandlers';
+
+describe('applyMessageEventToList', () => {
+        const baseMessage = (overrides: Partial<DtoMessage> = {}): DtoMessage => ({
+                id: '1',
+                channel_id: '10',
+                guild_id: '100',
+                content: 'hello',
+                type: 0,
+                author: null,
+                attachments: [],
+                mentions: [],
+                mention_roles: [],
+                mention_everyone: false,
+                pinned: false,
+                timestamp: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                flags: 0,
+                components: [],
+                embeds: [],
+                reactions: [],
+                ...overrides
+        });
+
+        it('appends new messages when channel matches and user is not at bottom', () => {
+                const event = {
+                        op: 0,
+                        t: 101,
+                        d: {
+                                message: {
+                                        ...baseMessage({ id: '2', content: 'second' }),
+                                        author_id: '42'
+                                }
+                        }
+                };
+
+                const result = applyMessageEventToList({
+                        event,
+                        currentMessages: [baseMessage()],
+                        selectedChannelId: '10',
+                        wasAtBottom: false
+                });
+
+                expect(result).not.toBeNull();
+                expect(result?.messages).toHaveLength(2);
+                expect(result?.messages[1].content).toBe('second');
+                expect(result?.messages[1].author).toBe('42');
+                expect(result?.shouldScrollToBottom).toBe(false);
+                expect(result?.newCountDelta).toBe(1);
+        });
+
+        it('merges updates for existing messages', () => {
+                const existing = baseMessage({ content: 'old content' });
+                const event = {
+                        op: 0,
+                        t: 101,
+                        d: {
+                                message: baseMessage({ content: 'updated content' })
+                        }
+                };
+
+                const result = applyMessageEventToList({
+                        event,
+                        currentMessages: [existing],
+                        selectedChannelId: '10',
+                        wasAtBottom: false
+                });
+
+                expect(result).not.toBeNull();
+                expect(result?.messages).toHaveLength(1);
+                expect(result?.messages[0].content).toBe('updated content');
+                expect(result?.newCountDelta).toBe(0);
+                expect(result?.shouldScrollToBottom).toBe(false);
+        });
+
+        it('removes messages for delete events', () => {
+                const event = {
+                        op: 0,
+                        t: 102,
+                        d: {
+                                channel_id: '10',
+                                message_id: '1'
+                        }
+                };
+
+                const result = applyMessageEventToList({
+                        event,
+                        currentMessages: [baseMessage()],
+                        selectedChannelId: '10',
+                        wasAtBottom: false
+                });
+
+                expect(result).not.toBeNull();
+                expect(result?.messages).toHaveLength(0);
+                expect(result?.newCountDelta).toBe(0);
+        });
+
+        it('ignores unread indicator frames with message_id when t=300', () => {
+                const event = {
+                        op: 0,
+                        t: 300,
+                        d: {
+                                channel_id: '10',
+                                message_id: '1'
+                        }
+                };
+
+                const result = applyMessageEventToList({
+                        event,
+                        currentMessages: [baseMessage()],
+                        selectedChannelId: '10',
+                        wasAtBottom: false
+                });
+
+                expect(result).toBeNull();
+        });
+
+        it('scrolls to bottom when sticking to the latest message', () => {
+                const event = {
+                        op: 0,
+                        t: 101,
+                        d: {
+                                message: baseMessage({ id: '3' })
+                        }
+                };
+
+                const result = applyMessageEventToList({
+                        event,
+                        currentMessages: [baseMessage()],
+                        selectedChannelId: '10',
+                        wasAtBottom: true
+                });
+
+                expect(result).not.toBeNull();
+                expect(result?.shouldScrollToBottom).toBe(true);
+                expect(result?.newCountDelta).toBe(0);
+        });
+});

--- a/src/lib/components/app/chat/messageEventHandlers.ts
+++ b/src/lib/components/app/chat/messageEventHandlers.ts
@@ -1,0 +1,99 @@
+import type { DtoMessage } from '$lib/api';
+
+function normalizeSnowflake(value: unknown): string | null {
+        if (value == null) return null;
+        try {
+                if (typeof value === 'string') return value;
+                if (typeof value === 'bigint') return value.toString();
+                if (typeof value === 'number') return BigInt(value).toString();
+                return String(value);
+        } catch {
+                try {
+                        return String(value);
+                } catch {
+                        return null;
+                }
+        }
+}
+
+export interface MessageEventContext {
+        event: any;
+        currentMessages: DtoMessage[];
+        selectedChannelId: string | null;
+        wasAtBottom: boolean;
+}
+
+export interface MessageEventResult {
+        messages: DtoMessage[];
+        newCountDelta: number;
+        shouldScrollToBottom: boolean;
+}
+
+export function applyMessageEventToList({
+        event,
+        currentMessages,
+        selectedChannelId,
+        wasAtBottom
+}: MessageEventContext): MessageEventResult | null {
+        if (!event || event.op !== 0) return null;
+
+        const eventType = typeof event?.t === 'number' ? event.t : null;
+        const payload = event?.d ?? {};
+
+        if (payload?.message) {
+                const incoming = payload.message as DtoMessage & { author_id?: unknown };
+                const channelId = normalizeSnowflake((incoming as any)?.channel_id);
+                const activeChannelId = normalizeSnowflake(selectedChannelId);
+                if (!channelId || !activeChannelId || channelId !== activeChannelId) return null;
+
+                if (!incoming.author && (incoming as any)?.author_id) {
+                        (incoming as any).author = (incoming as any).author_id;
+                }
+
+                const incomingId = normalizeSnowflake((incoming as any)?.id);
+                if (!incomingId) return null;
+
+                const idx = currentMessages.findIndex(
+                        (msg) => normalizeSnowflake((msg as any)?.id) === incomingId
+                );
+
+                if (idx >= 0) {
+                        const nextMessages = [...currentMessages];
+                        nextMessages[idx] = { ...nextMessages[idx], ...incoming };
+                        return {
+                                messages: nextMessages,
+                                newCountDelta: 0,
+                                shouldScrollToBottom: false
+                        };
+                }
+
+                return {
+                        messages: [...currentMessages, incoming],
+                        newCountDelta: wasAtBottom ? 0 : 1,
+                        shouldScrollToBottom: wasAtBottom
+                };
+        }
+
+        if (payload?.message_id) {
+                if (eventType === 300) return null;
+
+                const messageId = normalizeSnowflake(payload.message_id);
+                const channelId = normalizeSnowflake(payload.channel_id);
+                const activeChannelId = normalizeSnowflake(selectedChannelId);
+                if (!messageId || !channelId || !activeChannelId || channelId !== activeChannelId) return null;
+
+                const filtered = currentMessages.filter(
+                        (msg) => normalizeSnowflake((msg as any)?.id) !== messageId
+                );
+
+                if (filtered.length === currentMessages.length) return null;
+
+                return {
+                        messages: filtered,
+                        newCountDelta: 0,
+                        shouldScrollToBottom: false
+                };
+        }
+
+        return null;
+}


### PR DESCRIPTION
## Summary
- guard the message list websocket effect so only delete events remove messages
- extract message event handling into a reusable helper for the chat view
- add unit tests covering create, update, delete, and unread frames

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e1da8bbd4883228a86d4d232cbe394