### PR TITLE
fix: keep collapsed folder previews centered

### DIFF
--- a/src/lib/components/app/sidebar/ServerBar.svelte
+++ b/src/lib/components/app/sidebar/ServerBar.svelte
@@ -554,7 +554,7 @@
                                                         {:else}
                                                                 <div
                                                                         class={`grid h-full w-full grid-cols-2 grid-rows-2 gap-1 ${
-                                                                                folderHasUnread ? 'pr-1' : ''
+                                                                                folderHasUnread ? 'pl-1' : ''
                                                                         }`}
                                                                 >
                                                                         {#each item.guilds.slice(0, 4) as guildPreview, idx (guildPreview.guildId)}


### PR DESCRIPTION
## Summary
- adjust collapsed folder preview grid padding to keep icon cluster centered

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e1e4eb11fc8322af0e98f32a55c7bf